### PR TITLE
⚡ Bolt: Conditionally load form scripts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,8 +46,14 @@
   <script src="{{ 'assets/js/jquery.min.js' | relative_url }}" defer></script>
   <script src="{{ 'assets/js/bootstrap.bundle.min.js' | relative_url }}" defer></script>
   <script src="{{ 'assets/js/jquery.easing.min.js' | relative_url }}" defer></script>
-  <script src="{{ 'assets/js/jqBootstrapValidation.min.js' | relative_url }}" defer></script>
-  <script src="{{ 'assets/js/contact_me.js' | relative_url }}" defer></script>
+
+  {% if page.include_contact_form or page.include_play_group_form %}
+    <script src="{{ 'assets/js/jqBootstrapValidation.min.js' | relative_url }}" defer></script>
+  {% endif %}
+
+  {% if page.include_contact_form %}
+    <script src="{{ 'assets/js/contact_me.js' | relative_url }}" defer></script>
+  {% endif %}
 
   {%- comment -%} Load agency.min.js only on the home page (for shrink effect, etc.) {%- endcomment -%}
   {% if page.url == "/" %}
@@ -55,7 +61,9 @@
   {% endif %}
 
   {%- comment -%} Include custom script for Play Group form handling {%- endcomment -%}
-  <script src="{{ 'assets/js/play-group-form.js' | relative_url }}" defer></script>
+  {% if page.include_play_group_form %}
+    <script src="{{ 'assets/js/play-group-form.js' | relative_url }}" defer></script>
+  {% endif %}
 
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -241,8 +241,6 @@
     <script src="{{ 'assets/js/jquery.min.js' | relative_url }}" defer></script>
     <script src="{{ 'assets/js/bootstrap.bundle.min.js' | relative_url }}" defer></script>
     <script src="{{ 'assets/js/jquery.easing.min.js' | relative_url }}" defer></script>
-    <script src="{{ 'assets/js/jqBootstrapValidation.js' | relative_url }}" defer></script>
-    <script src="{{ 'assets/js/contact_me.js' | relative_url }}" defer></script>
     <script src="{{ 'assets/js/agency.min.js' | relative_url }}" defer></script>
     {% if site.data.style.search_engine_js %}
       <script src="{{ site.data.style.search_engine_js | relative_url }}" defer></script>

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,7 @@
 ---
 layout: default # Use the default layout
 title: "Contact an Atlanta Pediatric OT"
+include_contact_form: true
 display_title: "Contact Us"
 description: "Contact Maria O'Farrell at Playful Progressions for pediatric occupational therapy services, consultations, or to schedule an evaluation. We're here to help."
 subtitle: Get in touch with Playful Progressions

--- a/services.html
+++ b/services.html
@@ -1,6 +1,7 @@
 ---
 layout: default # Use the default layout for standard header/footer
 title: "Pediatric OT Services & Evaluations in Atlanta"
+include_play_group_form: true
 display_title: "Our Services"
 description: "Explore expert pediatric OT services in Atlanta. Playful Progressions offers evaluations, telehealth, and tailored interventions in Brookhaven, Buckhead, and more."
 subtitle: Detailed information about our offerings # Kept from your original front matter


### PR DESCRIPTION
💡 What: Only load `contact_me.js`, `play-group-form.js`, and `jqBootstrapValidation.min.js` on pages that need them (`contact.html`, `services.html`).
🎯 Why: Reduce JS payload on non-form pages (Home, Blog, etc.). `jqBootstrapValidation.js` is ~15KB unminified and unnecessary on most pages.
📊 Impact: Fewer HTTP requests and smaller download size on the majority of the site's pages.
🔬 Measurement: Verified via `grep` on generated site that scripts are present only on the intended pages.

---
*PR created automatically by Jules for task [1650521362801509099](https://jules.google.com/task/1650521362801509099) started by @ryanofarrell*