### PR TITLE
Fix implicit global variable $this in contact forms

### DIFF
--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -30,7 +30,7 @@ $(function () {
         firstName = name.split(" ").slice(0, -1).join(" ");
       }
 
-      $this = $("#sendMessageButton");
+      var $this = $("#sendMessageButton");
       $this.prop("disabled", true); // Disable submit button until AJAX call is complete to prevent duplicate messages
 
       // Perform AJAX POST request to the Formspree endpoint

--- a/assets/js/play-group-form.js
+++ b/assets/js/play-group-form.js
@@ -26,7 +26,7 @@ $(function () {
         firstName = name.split(" ").slice(0, -1).join(" ");
       }
 
-      $this = $("#sendPlayGroupMessageButton");
+      var $this = $("#sendPlayGroupMessageButton");
       $this.prop("disabled", true); // Disable submit button until AJAX call is complete to prevent duplicate messages
 
       // Perform AJAX POST request to the Formspree endpoint


### PR DESCRIPTION
This PR addresses a code health issue where the `$this` variable was being used without declaration in `assets/js/contact_me.js` and `assets/js/play-group-form.js`, leading to implicit global variable creation.

### Changes
- Added `var` declaration to `$this` in `assets/js/contact_me.js`.
- Added `var` declaration to `$this` in `assets/js/play-group-form.js` (proactive fix for similar pattern).

### Verification
- **Build**: Ran `npm run build` (which runs `jekyll build` and `purgecss`) successfully.
- **Frontend**: Verified the contact page loads correctly and `contact_me.js` is present using a Playwright script. The form functionality logic (AJAX submission) remains unchanged, only the variable scope is fixed.
- **Code Review**: Addressed feedback to remove build artifacts (`jekyll.log`, `.bundle/config`) before submission.


---
*PR created automatically by Jules for task [16362224115275210974](https://jules.google.com/task/16362224115275210974) started by @ryanofarrell*