### PR TITLE
⚡ Remove excessive Font Awesome preloading

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,18 +31,6 @@
 
   <link
     rel="preload"
-    href="{{ '/assets/css/webfonts/fa-solid-900.woff2' | relative_url }}"
-    as="font"
-    type="font/woff2"
-    crossorigin="anonymous">
-  <link
-    rel="preload"
-    href="{{ '/assets/css/webfonts/fa-brands-400.woff2' | relative_url }}"
-    as="font"
-    type="font/woff2"
-    crossorigin="anonymous">
-  <link
-    rel="preload"
     href="{{ '/assets/css/webfonts/fa-regular-400.woff2' | relative_url }}"
     as="font"
     type="font/woff2"


### PR DESCRIPTION
**What:** Removed `link rel="preload"` tags for `fa-solid-900.woff2` and `fa-brands-400.woff2` in `_includes/head.html`.

**Why:** To improve performance by reducing the number of critical resources downloaded during the initial page load. These fonts are used for icons and are not critical for the LCP text content. `font-display: swap` is used in the CSS, ensuring text remains visible.

**Measured Improvement:**
- Baseline: 8 preloaded fonts.
- Optimized: 6 preloaded fonts.
- Visual verification confirmed icons still load correctly via the CSS.

---
*PR created automatically by Jules for task [5578456882736543916](https://jules.google.com/task/5578456882736543916) started by @ryanofarrell*