### PR TITLE
🔒 Fix reverse tabnabbing vulnerability in navigation links

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -50,6 +50,7 @@
             aria-label="{{ icon.type }}"
             {% if icon.type == "instagram" %}
             target="_blank"
+            rel="noopener noreferrer"
             {% endif %}>
             <i class="{{ icon.icon }}"></i>
           </a>
@@ -100,6 +101,7 @@
               aria-label="{{ icon.type }}"
               {% if icon.type == "instagram" %}
               target="_blank"
+              rel="noopener noreferrer"
               {% endif %}>
               <i class="{{ icon.icon }}"></i>
             </a>


### PR DESCRIPTION
This PR fixes a "Reverse Tabnabbing" vulnerability in `_includes/navigation.html`. 

The vulnerability occurs when using `target="_blank"` without `rel="noopener noreferrer"`. This allows the newly opened page to access the `window.opener` object of the original page, potentially leading to phishing attacks.

The fix adds `rel="noopener noreferrer"` to the Instagram links in both the mobile and desktop navigation sections.

The change was verified by:
1.  Running `bundle exec jekyll build` to ensure no Liquid syntax errors.
2.  Using a Playwright script to verify that the generated HTML contains the correct attributes and that the layout is visually correct.


---
*PR created automatically by Jules for task [12224857031406924326](https://jules.google.com/task/12224857031406924326) started by @ryanofarrell*