### PR TITLE
Add engagement CTAs to key pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -30,6 +30,16 @@ permalink: /faq/
 
       {% comment %} Add more FAQ items here as needed in the data file {% endcomment %}
 
+      <div class="row mt-5">
+        <div class="col-lg-8 mx-auto text-center">
+          <div class="bg-light p-5 rounded">
+            <h3 class="section-heading mb-3">Still Have Questions?</h3>
+            <p class="text-muted mb-4">We're here to help! Reach out to us directly for more information or specific inquiries.</p>
+            <a class="btn btn-primary btn-xl text-uppercase" href="{{ '/contact/' | relative_url }}">Contact Us</a>
+          </div>
+        </div>
+      </div>
+
       </div>
     </div>
   </div>

--- a/meet-maria.html
+++ b/meet-maria.html
@@ -44,6 +44,16 @@ permalink: /meet-maria/
           </div>
         {% endif %}
 
+        <div class="row mt-5">
+          <div class="col-lg-8 mx-auto text-center">
+            <div class="bg-light p-5 rounded">
+              <h3 class="section-heading mb-3">Ready to Work with Maria?</h3>
+              <p class="text-muted mb-4">Discover how her personalized approach can support your child's growth and development.</p>
+              <a class="btn btn-primary btn-xl text-uppercase" href="{{ '/services/' | relative_url }}">View Services</a>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
   </div>

--- a/services.html
+++ b/services.html
@@ -286,5 +286,15 @@ permalink: /services/
       </section>
     {% endfor %}
 
+    <div class="row mt-5">
+      <div class="col-lg-8 mx-auto text-center">
+        <div class="bg-light p-5 rounded">
+          <h2 class="section-heading mb-3">Not Sure Where to Begin?</h2>
+          <p class="text-muted mb-4">Every child is unique. If you're unsure which service is right for you, let's chat about your specific needs.</p>
+          <a class="btn btn-primary btn-xl text-uppercase" href="{{ '/contact/' | relative_url }}">Get in Touch</a>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>


### PR DESCRIPTION
This change implements 'Soft Hook' Call-to-Action (CTA) sections on the Meet Maria, Services, and FAQ pages. These additions are designed to improve user engagement by providing clear next steps at the bottom of these pages, preventing "dead ends" in the user journey.

**Changes:**
- **`meet-maria.html`:** Added a "Ready to Work with Maria?" section linking to the Services page.
- **`services.html`:** Added a "Not Sure Where to Begin?" section linking to the Contact page.
- **`faq.html`:** Added a "Still Have Questions?" section linking to the Contact page.

**Technical Details:**
- Utilized existing Bootstrap 4 classes (`container`, `row`, `col-lg-8`, `mx-auto`, `bg-light`, `p-5`, `text-center`, `btn`, `btn-primary`, `btn-xl`) ensuring consistent styling and mobile responsiveness.
- Used Jekyll's `{{ '/path/' | relative_url }}` filter for robust internal linking.
- Verified that PurgeCSS (part of the build process) retains these classes as they are standard framework classes.

**Verification:**
- Built the site locally using `bundle exec jekyll build`.
- Verified the presence of the new sections and their content using `grep`.
- Visually verified the changes by generating screenshots of the modified pages (Meet Maria, Services, FAQ) using a Playwright script running against a local server. The screenshots confirmed correct layout, styling, and text content.


---
*PR created automatically by Jules for task [15052148532947072409](https://jules.google.com/task/15052148532947072409) started by @ryanofarrell*