### PR TITLE
feat(a11y): add skip to main content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-09 - Loading State for Formspree Forms
 **Learning:** Adding a visual loading state (spinner + text change) to Formspree forms significantly improves feedback during the async submission process, which can otherwise feel unresponsive.
 **Action:** Apply this pattern (spinner icon + text update + disable button) to all async form submissions in Jekyll/jQuery sites.
+
+## 2026-02-12 - Skip to Main Content Link
+**Learning:** Keyboard users and screen reader users need a way to bypass repetitive navigation menus to access the main content quickly. A "Skip to main content" link is a critical accessibility requirement.
+**Action:** Implemented a visible-on-focus skip link using a custom `.skip-link` component and `<main id="main-content">` wrapper in `_layouts/default.html`. This pattern should be standard for all layouts.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,8 @@
     <body id="page-top" class="body-light-background">
   {% endif %}
 
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
   {%- comment -%} Conditionally add the IntersectionObserver sentinel ONLY on the homepage {%- endcomment -%}
   {% if page.layout == "home" %}
     <div id="navbar-sentinel" style="position: absolute; top: 100px;"></div>
@@ -24,7 +26,9 @@
     {% include mini-masthead.html %}
   {% endif %}
 
-  {{ content }}
+  <main id="main-content">
+    {{ content }}
+  </main>
 
   {% include footer.html %}
 

--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -6,7 +6,11 @@
   {% comment %} Add body class for styling based on background {% endcomment %}
   <body class="body-light-background">
 
-    {{ content }}
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+
+    <main id="main-content">
+      {{ content }}
+    </main>
 
   {% comment %}
     Optionally include minimal scripts here if needed for the 404 page,

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,9 +5,12 @@
 
   <body id="page-top" class="body-light-background">
 
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+
     {% include navigation.html %}
 
-    <article class="post-content page-section">
+    <main id="main-content">
+      <article class="post-content page-section">
       <div class="container">
         <div class="row justify-content-center">
           <div class="col-lg-10">
@@ -230,7 +233,8 @@
           </div>
         </div>
       </div>
-    </article>
+      </article>
+    </main>
 
     {% include footer.html %}
 

--- a/_sass/components/_skip-link.scss
+++ b/_sass/components/_skip-link.scss
@@ -1,0 +1,21 @@
+.skip-link {
+  position: absolute;
+  top: -9999px;
+  left: 0;
+  z-index: 9999;
+  padding: 1rem;
+  background-color: $white;
+  color: $primary;
+  text-decoration: none;
+  border: 1px solid $primary;
+
+  &:focus {
+    top: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -75,6 +75,7 @@ $contact-image: "{{ site.data.style.contact-image }}";
 @import "components/navbar.scss";
 @import "components/client-scroll.scss";
 @import "components/_blog-filter.scss";
+@import "components/skip-link";
 
 // Layout
 @import "layout/masthead.scss";


### PR DESCRIPTION
Added a "Skip to main content" link to all layouts (_layouts/default.html, _layouts/post.html, _layouts/minimal.html) and wrapped the main content in a `<main id="main-content">` tag. This improves accessibility for keyboard and screen reader users. The skip link is styled in `_sass/components/_skip-link.scss` and imported in `assets/css/agency.scss`.

---
*PR created automatically by Jules for task [1844959307878070836](https://jules.google.com/task/1844959307878070836) started by @ryanofarrell*