### PR TITLE
Improve internal linking for SEO in blog post

### DIFF
--- a/_posts/2026-01-29-indoor-play-areas-atlanta.md
+++ b/_posts/2026-01-29-indoor-play-areas-atlanta.md
@@ -12,15 +12,15 @@ header:
 image: /assets/images/processed/blog/indoor-play-atlanta.jpeg
 ---
 
-I’m a big believer in outdoor play—for the sensory input, the fresh air, and the endless opportunities for movement. That said, I did not move to Atlanta to experience weeks of subfreezing temperatures. When it’s cold, dark, and everyone is bouncing off the walls, staying home with two young children who need movement to regulate is… not the vibe.
+I’m a big believer in outdoor play—for the sensory input, the fresh air, and the endless opportunities for movement. That said, I did not move to Atlanta to experience weeks of subfreezing temperatures. When it’s cold, dark, and everyone is bouncing off the walls, staying home with two young children who need movement to [regulate](/services/#treatments) is… not the vibe.
 
 When we absolutely have to get out of the house, these are our five favorite indoor go-tos for cold days—places where kids can move their bodies and parents can breathe.
 
-## 1. HippoHopp | Brookhaven
+## 1. HippoHopp | [Brookhaven](/service-areas/)
 
 [HippoHopp](https://hippohopp.com/){:target="_blank"} is a staple for indoor play in Atlanta. With multiple bouncy houses, a large climbing structure, and a thoughtfully designed toddler area, this space works well for a wide range of ages. Parents can relax in seating areas or jump in and play alongside their kids (which mine always request).
 
-From an OT perspective, Hippo Hopp provides excellent opportunities for **proprioceptive input**, **vestibular movement**, and **motor planning**. On busy days, the environment can feel overstimulating, but the staff is incredibly accommodating and often able to provide quieter space when party rooms are not in use.
+From an OT perspective, Hippo Hopp provides excellent opportunities for **[proprioceptive input](/services/#treatments)**, **[vestibular movement](/services/#treatments)**, and **[motor planning](/services/#treatments)**. On busy days, the environment can feel overstimulating, but the staff is incredibly accommodating and often able to provide quieter space when party rooms are not in use.
 
 **OT Tips:**
 *   **Take Breaks:** Encourage your child to take movement breaks between bouncy houses to avoid sensory overload.
@@ -28,7 +28,7 @@ From an OT perspective, Hippo Hopp provides excellent opportunities for **propri
 *   **Regulation:** Use deep pressure (tight hugs, squeezes, or wall pushes) before leaving or frequently throughout the experience to support regulation.
 *   **Timing:** Visit during off-peak hours if your child is sensitive to noise or crowds.
 
-## 2. Atlanta History Center | Buckhead
+## 2. Atlanta History Center | [Buckhead](/service-areas/)
 
 The [Atlanta History Center](https://www.atlantahistorycenter.com/){:target="_blank"} features a newer child-friendly play area that offers something for nearly every age. Toddlers can explore giant foam blocks and open-ended play, while older children engage in multisensory exhibits—including a slide my daughter still talks about.
 
@@ -50,18 +50,18 @@ The children’s area, **NatureQuest**, is where we spend most of our time. Rope
 *   **Regulation Breaks:** Use the quiet exhibits as a built-in regulation break when the play area gets too loud.
 *   **Body Awareness:** Practice body awareness by talking through where feet and hands go on rope bridges. If your child experiences gravitational insecurity, use deep pressure to regulate before and after exploring.
 
-## 4. The Alliance Theatre | Midtown
+## 4. The Alliance Theatre | [Midtown](/service-areas/)
 
 The [Alliance Theatre](https://alliancetheatre.org/){:target="_blank"} recently opened PNC PlaySpace, a free indoor play experience for children ages 0–5. The current exhibit, *Bossa Nova Baby*, immerses children in a sensory-rich Brazilian rainforest environment designed for movement, exploration, and engagement.
 
-Beyond PlaySpace, the Alliance offers outstanding child-friendly performances. These shows are intentionally designed for young audiences—movement is encouraged, seating is flexible, and children are invited to experience theater with their whole bodies. (Yes, this OT fully supports that.) I’ve even recommended their dinosaur show to feeding clients for its thoughtful exploration of sitting at the dinner table.
+Beyond PlaySpace, the Alliance offers outstanding child-friendly performances. These shows are intentionally designed for young audiences—movement is encouraged, seating is flexible, and children are invited to experience theater with their whole bodies. (Yes, this OT fully supports that.) I’ve even recommended their dinosaur show to [feeding clients](/services/#treatments) for its thoughtful exploration of sitting at the dinner table.
 
 **OT Tips:**
 *   **Child-Led Play:** Let children explore the space at their own pace—there’s no “right” way to play.
 *   **Active Sitting:** Use performances to practice sitting with movement (wiggles are allowed!).
 *   **Transitions:** Pair shows with PlaySpace time to meet sensory needs before sitting for a show.
 
-## 5. Kids Empire | Chamblee
+## 5. Kids Empire | [Chamblee](/service-areas/)
 
 [Kids Empire](https://www.kidsempire.com/park/plaza-fiesta){:target="_blank"} is a large indoor play space offering climbing, sliding, biking, dancing, and opportunities for safe risk-taking. The toddler area includes a big ball pit that provides excellent proprioceptive and tactile input, along with climbing and crawling challenges.
 


### PR DESCRIPTION
Added internal links to 'indoor-play-areas-atlanta.md' connecting technical terms to services and neighborhood names to service areas, enhancing the site's information scent and SEO relevance.

---
*PR created automatically by Jules for task [7035930229963006516](https://jules.google.com/task/7035930229963006516) started by @ryanofarrell*