### PR TITLE
Enhance MedicalBusiness Schema with knowsAbout

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -59,6 +59,13 @@
           }{%- unless forloop.last -%},{%- endunless -%}
         {%- endfor -%}
       ],
+      {%- assign expertise = "" | split: "" -%}
+      {%- for group in sitetext.about.what-we-treat -%}
+        {%- for item in group.items -%}
+          {%- assign expertise = expertise | push: item -%}
+        {%- endfor -%}
+      {%- endfor -%}
+      "knowsAbout": {{ expertise | jsonify }},
       "sameAs": ["{{ site.instagram_url }}", "{{ site.google_business_url }}"]
     }
   </script>


### PR DESCRIPTION
Enhanced the `MedicalBusiness` Schema.org data in `_includes/head/custom.html` by adding a `knowsAbout` property. This property is dynamically populated using the list of treatments found in `_data/sitetext.yml`, ensuring that the site's "information scent" regarding its services is clearly communicated to search engines. This aligns with the goal of improving local SEO and clarifying "What" the business offers.
Verified the change by building the site and inspecting the generated JSON-LD.

---
*PR created automatically by Jules for task [5338862262438504786](https://jules.google.com/task/5338862262438504786) started by @ryanofarrell*