### PR TITLE
feat(a11y): Make testimonial carousel indicators keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-02-12 - Skip to Main Content Link
 **Learning:** Keyboard users and screen reader users need a way to bypass repetitive navigation menus to access the main content quickly. A "Skip to main content" link is a critical accessibility requirement.
 **Action:** Implemented a visible-on-focus skip link using a custom `.skip-link` component and `<main id="main-content">` wrapper in `_layouts/default.html`. This pattern should be standard for all layouts.
+
+## 2026-02-13 - Carousel Indicator Accessibility
+**Learning:** Carousel indicators are often implemented as non-interactive list items (`<li>`), making them inaccessible to keyboard users. Screen readers also need context about what these items do.
+**Action:** Added `role="button"`, `tabindex="0"`, `aria-label="Slide X"`, and `onkeydown` handlers (for Enter/Space) to testimonial carousel indicators to ensure full keyboard accessibility.

--- a/_includes/testimonial.html
+++ b/_includes/testimonial.html
@@ -14,8 +14,13 @@
           <li
             data-target="#testimonial-carousel"
             data-slide-to="{{ forloop.index0 }}"
+            role="button"
+            tabindex="0"
+            aria-label="Slide {{ forloop.index }}"
+            onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click();}"
             {% if forloop.first %}
             class="active"
+            aria-current="true"
             {% endif %}></li>
         {% endfor %}
       </ol>


### PR DESCRIPTION
Updated `_includes/testimonial.html` to add `role="button"`, `tabindex="0"`, `aria-label`, and `onkeydown` handlers to the carousel indicators, ensuring they are accessible to keyboard users and screen readers. Also documented the pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8141613578472224058](https://jules.google.com/task/8141613578472224058) started by @ryanofarrell*