### PR TITLE
Improve keyboard focus for navbar contact icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-13 - Carousel Indicator Accessibility
 **Learning:** Carousel indicators are often implemented as non-interactive list items (`<li>`), making them inaccessible to keyboard users. Screen readers also need context about what these items do.
 **Action:** Added `role="button"`, `tabindex="0"`, `aria-label="Slide X"`, and `onkeydown` handlers (for Enter/Space) to testimonial carousel indicators to ensure full keyboard accessibility.
+
+## 2026-02-14 - Focus States on Custom Icons
+**Learning:** Custom interactive elements, like icon-only links (`.contact-icon`), often lack visible `:focus` states, making them difficult for keyboard users to navigate.
+**Action:** Ensure all interactive elements have a clear, high-contrast `:focus` state (e.g., outline or box-shadow ring) that is distinct from the default browser style if custom styling is applied.

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -88,7 +88,17 @@
   /* Common styles for Contact Icons */
   /* Base size and spacing between icons (mobile spacing) */
   .contact-icon {
+    display: inline-block; // Ensure it respects box model properties
     font-size: 1.3rem; /* Adjust icon size */
+    border-radius: 50%; // Rounded for focus ring
+    padding: 2px; // specific padding to avoid overlap with content
+    transition: box-shadow 0.2s; // Smooth transition
+
+    &:focus {
+      outline: none; // Remove default outline
+      box-shadow: 0 0 0 0.2rem rgba($action, 0.5); // Add a visible ring using the action color
+    }
+
     /* Default color defined below */
 
     /* Mobile Contact Icon Active/Focus Color */


### PR DESCRIPTION
I audited the navigation bar (`_includes/navigation.html`) and identified that the contact icons (`.contact-icon`) lacked a visible focus state for keyboard users, violating WCAG 2.4.7.

To fix this, I updated `_sass/components/_navbar.scss` to:
- Add a `:focus` state with a high-contrast `box-shadow` ring using the `$action` color.
- Remove the default outline to ensure a consistent custom appearance.
- Ensure the icons display as `inline-block` with `border-radius: 50%` to support the circular focus ring.

I also documented this recurring accessibility pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [15192061581871575740](https://jules.google.com/task/15192061581871575740) started by @ryanofarrell*