### PR TITLE
Add 6-9 months wake windows blog post

### DIFF
--- a/_posts/2024-04-19-wake-windows-3-6-months.md
+++ b/_posts/2024-04-19-wake-windows-3-6-months.md
@@ -13,7 +13,7 @@ image: /assets/images/processed/blog/wake-windows-3-6.jpeg
 
 ---
 
-_For 0-3 months [click here](wake-windows-0-3-months)_
+_For 0-3 months [click here](wake-windows-0-3-months)_ | _For 6-9 months [click here](wake-windows-6-9-months)_
 
 The 3-6 month phase was one of my favorites!  You are finally getting some positive feedback and encouragement from your little one– the smiles, the coos, watching them make connections and learn, it is truly the best!  Here are some ways to facilitate 3-6 month development!
 

--- a/_posts/2024-06-19-wake-windows-6-9-months.md
+++ b/_posts/2024-06-19-wake-windows-6-9-months.md
@@ -1,0 +1,41 @@
+---
+layout: post
+title: How to fill Wake Windows 6-9 Months
+date: 2024-06-19 00:00:00 -0400
+categories: posts
+excerpt: "Your baby is sitting up, exploring, and maybe even crawling! Discover OT-approved activities for 6-9 month wake windows to foster motor skills, object permanence, and sensory exploration."
+classes: wide
+tag: Posts
+concepts: ["infant activities", "wake windows", "crawling", "sitting play", "object permanence", "fine motor", "sensory play"]
+# header:
+#     teaser:
+# image:
+---
+
+_For 3-6 months [click here](wake-windows-3-6-months)_
+
+The 6-9 month phase is an absolute game-changer! Suddenly, your baby is interacting with their environment in entirely new ways. They are likely sitting independently, rolling with purpose, starting solids, and maybe even scooting or crawling! It is such a fun and busy time, but it can also leave you wondering how to keep them entertained while supporting their development. Here are some OT-approved ways to fill those wake windows for your 6-9 month old!
+
+## Core Motor Skills
+
+### Independent sitting play
+Once your baby is sitting independently or with minimal support, the whole world opens up for them. When they no longer have to use their hands to hold themselves up, they can use them to play! Place toys around them in a semi-circle to encourage reaching and twisting. This works on their core strength, trunk rotation, and balance. Make sure to stay close by for safety, or place a boppy pillow behind them just in case they topple over backward.
+
+### Obstacle courses
+If your baby is showing signs of wanting to move (getting up on all fours, rocking, scooting backwards), encourage them! Create a mini obstacle course with couch cushions, pillows, or rolled-up blankets on the floor. Place a highly motivating toy just out of reach to give them a reason to move over the obstacles. This provides amazing proprioceptive input and builds the bilateral coordination needed for crawling.
+
+## Sensory and Fine Motor
+
+### Messy play and textures
+With the introduction of solids comes the perfect opportunity for messy play! Babies learn so much through their tactile system. Let them squish purees, yogurt, or mashed avocado with their hands during mealtimes. Outside of the highchair, you can fill a shallow baking pan with a little bit of water and let them splash while sitting on the floor. It’s fantastic for their sensory development and makes them more tolerant of different textures later on.
+
+### Pincer grasp practice
+Around 8-9 months, you might notice your baby trying to pick up smaller items using their thumb and index finger. This is the beginning of the pincer grasp! You can facilitate this by offering safe, small items like O-shaped cereal or puffs. You can also use a muffin tin and place a toy or a snack in each cup. Reaching into the small spaces encourages them to isolate their fingers instead of using a whole-hand raking motion.
+
+## Cognitive Milestones
+
+### The magic of object permanence
+At this age, babies begin to understand that an object still exists even if they can't see it—this is called object permanence! Peek-a-boo is a classic for a reason. You can also hide a favorite toy under a small blanket or cup while they are watching and encourage them to find it. This cognitive milestone is huge and sets the stage for problem-solving skills down the road.
+
+### Container play
+One of the most satisfying things for a baby this age is simply taking things out of a container and putting them back in. Give them a clean, empty wipes container or a small basket filled with soft blocks, large rings, or even rolled-up socks. This seemingly simple activity works on their release (letting go of an object intentionally is a new skill!), bilateral coordination, and visual-motor integration.


### PR DESCRIPTION
Drafted a new post 'How to fill Wake Windows 6-9 Months' (`_posts/2024-06-19-wake-windows-6-9-months.md`) targeting the identified content gap for 6-9 months wake windows, following up on the existing 0-3 and 3-6 month articles. Used the "OT-Mom" voice with correct Jekyll Front Matter and `Posts` tag. Adhered strictly to the image freeze constraints by avoiding any `teaser` or `image` values. Updated the older 3-6 months post to include a forward link to the newly created post.

---
*PR created automatically by Jules for task [5930358469727848715](https://jules.google.com/task/5930358469727848715) started by @ryanofarrell*