### PR TITLE
Fix decorative FontAwesome icons missing aria-hidden

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,11 @@
 ## 2026-02-14 - Focus States on Custom Icons
 **Learning:** Custom interactive elements, like icon-only links (`.contact-icon`), often lack visible `:focus` states, making them difficult for keyboard users to navigate.
 **Action:** Ensure all interactive elements have a clear, high-contrast `:focus` state (e.g., outline or box-shadow ring) that is distinct from the default browser style if custom styling is applied.
+# Palette's Accessibility Audit Journal
+
+## Identified Anti-Patterns
+
+### 1. Decorative FontAwesome Icons Missing `aria-hidden`
+- **Description:** Several FontAwesome icons (`<i class="fas fa-...">`) used purely for visual decoration alongside descriptive text lack the `aria-hidden="true"` attribute.
+- **Impact:** Screen readers might announce these decorative icons in confusing ways (e.g., "phone-alt" alongside actual phone numbers), violating WCAG guidelines for handling decorative elements.
+- **Resolution:** Always add `aria-hidden="true"` to any `<i>` tag that serves only a decorative purpose and is accompanied by visually hidden or explicit text.

--- a/_includes/book-calendly.html
+++ b/_includes/book-calendly.html
@@ -7,8 +7,8 @@
     <div class="border p-4 rounded bg-light text-center gap-y-5">
       <p>
         <a href="tel:{{ site.phone-numeric }}" class="text-dark">
-          <i class="fas fa-phone-alt mr-2 fa-sm d-inline d-sm-none"></i>
-          <i class="fas fa-phone-alt mr-3 fa-lg d-none d-sm-inline"></i>
+          <i class="fas fa-phone-alt mr-2 fa-sm d-inline d-sm-none" aria-hidden="true"></i>
+          <i class="fas fa-phone-alt mr-3 fa-lg d-none d-sm-inline" aria-hidden="true"></i>
 
           <span class="h6 d-inline d-sm-none">{{ site.phone-text }}</span>
           <span class="h4 d-none d-sm-inline">{{ site.phone-text }}</span>
@@ -16,8 +16,8 @@
       </p>
       <p>
         <a href="mailto:{{ site.email }}" class="text-dark">
-          <i class="fas fa-envelope mr-2 fa-sm d-inline d-sm-none"></i>
-          <i class="fas fa-envelope mr-3 fa-lg d-none d-sm-inline"></i>
+          <i class="fas fa-envelope mr-2 fa-sm d-inline d-sm-none" aria-hidden="true"></i>
+          <i class="fas fa-envelope mr-3 fa-lg d-none d-sm-inline" aria-hidden="true"></i>
 
           <span class="h6 d-inline d-sm-none">{{ site.email }}</span>
           <span class="h4 d-none d-sm-inline">{{ site.email }}</span>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -22,7 +22,7 @@
         aria-expanded="false"
         aria-label="Toggle navigation">
         Menu
-        <i class="fas fa-bars"></i>
+        <i class="fas fa-bars" aria-hidden="true"></i>
       </button>
 
       <div class="mobile-contact-icons">


### PR DESCRIPTION
- Found decorative FontAwesome icons lacking `aria-hidden="true"` which causes screen reader confusion.
- Added `aria-hidden="true"` to `<i class="fas fa-...">` tags in `_includes/book-calendly.html` and `_includes/navigation.html`.
- Logged this anti-pattern to `.Jules/palette.md` to prevent recurrence.

---
*PR created automatically by Jules for task [15482015318133466451](https://jules.google.com/task/15482015318133466451) started by @ryanofarrell*