### PR TITLE
🔒 [validate AJAX form action URLs]

### DIFF
--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -19,6 +19,12 @@ $(function () {
       // var url = "https://formspree.io/" + "{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}"; // Removed this line
       var url = $form.attr("action"); // Get the submission URL directly from the form's action attribute
 
+      // Basic URL validation: Ensure it starts with the expected Formspree prefix
+      if (!url || url.indexOf("https://formspree.io/") !== 0) {
+        console.error("Invalid form action URL: " + url);
+        return;
+      }
+
       var name = $("input#name").val();
       var email = $("input#email").val();
       // var phone = $("input#phone").val(); // Removed phone as per previous change

--- a/assets/js/play-group-form.js
+++ b/assets/js/play-group-form.js
@@ -17,6 +17,13 @@ $(function () {
 
       // Get values from FORM
       var url = $form.attr("action"); // Get the submission URL directly from the form's action attribute
+
+      // Basic URL validation: Ensure it starts with the expected Formspree prefix
+      if (!url || url.indexOf("https://formspree.io/") !== 0) {
+        console.error("Invalid form action URL: " + url);
+        return;
+      }
+
       var name = $("input#playGroupName").val();
       var email = $("input#playGroupEmail").val();
       var firstName = name; // For Success/Failure Message


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where form `action` attributes were used as AJAX URLs without validation in `assets/js/contact_me.js` and `assets/js/play-group-form.js`.

⚠️ **Risk:** If left unfixed, an attacker could potentially manipulate the form's `action` attribute in the DOM to redirect sensitive form submissions (containing names and emails) to a malicious server.

🛡️ **Solution:** Implemented a validation step in both scripts that checks if the submission URL starts with the authorized prefix `https://formspree.io/`. If the URL is invalid, the submission is aborted and an error is logged.

---
*PR created automatically by Jules for task [8810323418930248972](https://jules.google.com/task/8810323418930248972) started by @ryanofarrell*