### PR TITLE
Add soft hooks to post and contact pages to prevent dead ends

### DIFF
--- a/_includes/soft_hook.html
+++ b/_includes/soft_hook.html
@@ -5,7 +5,11 @@
         <div class="bg-light p-5 rounded">
           <h2 class="section-heading mb-3">{{ include.title | default: "Ready to connect?" }}</h2>
           <p class="text-muted mb-4">{{ include.text | default: "Every child is unique. If you're looking for personalized support or just have a few questions, feel free to reach out." }}</p>
-          <a class="btn btn-primary btn-xl text-uppercase" href="{{ include.btn_link | default: '/contact/' | relative_url }}">{{ include.btn_text | default: "Get in Touch" }}</a>
+          {% if include.external %}
+            <a class="btn btn-primary btn-xl text-uppercase" href="{{ include.btn_link }}" target="_blank" rel="noopener noreferrer">{{ include.btn_text | default: "Get in Touch" }}</a>
+          {% else %}
+            <a class="btn btn-primary btn-xl text-uppercase" href="{{ include.btn_link | default: '/contact/' | relative_url }}">{{ include.btn_text | default: "Get in Touch" }}</a>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -244,6 +244,9 @@
                   {% endif %}
                 </div>
               </div>
+
+              {% include soft_hook.html title="Want more tips?" text="Follow us on Instagram for daily pediatric OT activities, parenting tips, and behind-the-scenes!" btn_text="Follow on Instagram" btn_link=site.instagram_url external=true %}
+
             </div>
           </div>
         </div>

--- a/contact.html
+++ b/contact.html
@@ -116,3 +116,5 @@ permalink: /contact/
     </div>
   </div>
 </section>
+
+{% include soft_hook.html title="Not quite ready to reach out?" text="That's okay! You can still learn more about what we do by following us on Instagram or checking out our blog." btn_text="Read the Blog" btn_link="/blog/" %}

--- a/server.log
+++ b/server.log
@@ -1,0 +1,23 @@
+127.0.0.1 - - [11/Mar/2026 05:21:48] "GET /contact/ HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:21:53] code 404, message File not found
+127.0.0.1 - - [11/Mar/2026 05:21:53] "GET /blog/2024/01/06/five-minute-friday-blanket-rides.html HTTP/1.1" 404 -
+127.0.0.1 - - [11/Mar/2026 05:21:57] code 404, message File not found
+127.0.0.1 - - [11/Mar/2026 05:21:57] "GET /five-minute-friday-blanket-rides.html HTTP/1.1" 404 -
+127.0.0.1 - - [11/Mar/2026 05:22:06] "GET /blog/five-minute-friday-blanket-rides.html HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:43] code 404, message File not found
+127.0.0.1 - - [11/Mar/2026 05:22:43] "GET /blog/2024/01/06/five-minute-friday-blanket-rides.html HTTP/1.1" 404 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /contact/ HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/fonts/montserrat-v30-latin-700.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/fonts/merriweather-v32-latin-italic.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/css/agency.css HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/fonts/roboto-slab-v35-latin-regular.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/images/full-res/logo.svg HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/js/jquery.min.js HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/js/jquery.easing.min.js HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/js/contact_me.js HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/js/bootstrap.bundle.min.js HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/js/jqBootstrapValidation.min.js HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/fonts/merriweather-v32-latin-700italic.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/css/webfonts/fa-solid-900.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/css/webfonts/fa-brands-400.woff2 HTTP/1.1" 200 -
+127.0.0.1 - - [11/Mar/2026 05:22:45] "GET /assets/fonts/montserrat-v30-latin-regular.woff2 HTTP/1.1" 200 -


### PR DESCRIPTION
Added soft hooks to post and contact pages to prevent dead ends.

Changes:
- Updated `_includes/soft_hook.html` to support an `external` flag for rendering links with `target="_blank"` and `rel="noopener noreferrer"`.
- Added a new soft hook to `_layouts/post.html` at the bottom of the page that encourages users to follow the business on Instagram.
- Added a new soft hook to `contact.html` below the form that provides a low-pressure alternative (reading the blog) for users not quite ready to reach out.

---
*PR created automatically by Jules for task [10626500974535503839](https://jules.google.com/task/10626500974535503839) started by @ryanofarrell*