### PR TITLE
SEO Enhancement: Add `concepts` to Schema.org keywords

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -13,6 +13,9 @@
       {%- else -%}
         "description": {{ content | strip_html | truncatewords: 50 | normalize_whitespace | jsonify }},
         {%- endif -%}
+        {%- if page.concepts -%}
+        "keywords": {{ page.concepts | join: ", " | jsonify }},
+        {%- endif -%}
         {%- if page.header.teaser -%}
           "image" : "{{ page.header.teaser | relative_url | prepend: site.url }}",
           {%- endif -%}


### PR DESCRIPTION
As part of local SEO enhancements, `page.concepts` is now explicitly added to the JSON-LD `Article` schema via `_includes/head/custom.html`, bridging the semantic gap in Schema.org optimization.

---
*PR created automatically by Jules for task [15443792215610039683](https://jules.google.com/task/15443792215610039683) started by @ryanofarrell*