### PR TITLE
Refine Button Focus States with Semantic Colors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,6 @@
 - **Description:** Several FontAwesome icons (`<i class="fas fa-...">`) used purely for visual decoration alongside descriptive text lack the `aria-hidden="true"` attribute.
 - **Impact:** Screen readers might announce these decorative icons in confusing ways (e.g., "phone-alt" alongside actual phone numbers), violating WCAG guidelines for handling decorative elements.
 - **Resolution:** Always add `aria-hidden="true"` to any `<i>` tag that serves only a decorative purpose and is accompanied by visually hidden or explicit text.
+## Focus States and Colors
+- **Anti-Pattern:** Using hardcoded RGB or hex values (e.g., `rgba(254, 209, 55, 0.5)`) for `:focus` state `box-shadow` rules on interactive elements like buttons.
+- **Solution:** Use semantic color variables (e.g., `$primary`, `$secondary`, `$action`) within the `rgba()` function to ensure focus rings are dynamically consistent with the element's specific color variant.

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -32,7 +32,7 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba(254, 209, 55, 0.5) !important;
+    box-shadow: 0 0 0 0.2rem rgba($primary, 0.5) !important;
   }
   &:disabled,
   &.disabled {
@@ -54,7 +54,7 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba(254, 209, 55, 0.5) !important;
+    box-shadow: 0 0 0 0.2rem rgba($secondary, 0.5) !important;
   }
 }
 .btn-action {
@@ -69,6 +69,6 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba(254, 209, 55, 0.5) !important;
+    box-shadow: 0 0 0 0.2rem rgba($action, 0.5) !important;
   }
 }


### PR DESCRIPTION
- Modified `_sass/components/_buttons.scss` to use `$primary`, `$secondary`, and `$action` color variables for focus box-shadows instead of a hardcoded RGB value.
- Added documentation about this anti-pattern to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1422426079645463528](https://jules.google.com/task/1422426079645463528) started by @ryanofarrell*