### PR TITLE
🔒 [security fix] Fix command injection vulnerability in process_my_images.sh

### DIFF
--- a/process_my_images.sh
+++ b/process_my_images.sh
@@ -92,12 +92,9 @@ find "$SOURCE_BASE_DIR" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "
 
         # Create AVIF and WebP for the current size
         # We use > to ensure we don't upscale small images
-        avif_resize_cmd="magick \"$source_image_path\" -resize '${width}>' +profile \"*\" -quality $IM_AVIF_QUALITY \"$local_avif_path\""
-        webp_resize_cmd="magick \"$source_image_path\" -resize '${width}>' -quality $IM_WEBP_QUALITY \"$local_webp_path\""
-
         if [ "$DRY_RUN" = false ]; then
-            eval "$avif_resize_cmd"
-            eval "$webp_resize_cmd"
+            magick "$source_image_path" -resize "${width}>" +profile "*" -quality $IM_AVIF_QUALITY "$local_avif_path"
+            magick "$source_image_path" -resize "${width}>" -quality $IM_WEBP_QUALITY "$local_webp_path"
         fi
     done
     # --- END: NEW LOGIC ---


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection in the `process_my_images.sh` script where the `eval` command was used to execute image resizing commands containing shell variables derived from filenames.
⚠️ **Risk:** If an attacker could control filenames (e.g., via a malicious pull request or by influencing the build environment), they could execute arbitrary shell commands with the same privileges as the script runner.
🛡️ **Solution:** The fix replaces the `eval` statement with direct command execution. All variables, including file paths and the resize geometry, are now properly double-quoted to ensure they are treated as single arguments by the shell, preventing metacharacter interpretation.

---
*PR created automatically by Jules for task [8302242324545340397](https://jules.google.com/task/8302242324545340397) started by @ryanofarrell*