### PR TITLE
🔒 [security fix] Fix command injection in process_my_images.sh

### DIFF
--- a/process_my_images.sh
+++ b/process_my_images.sh
@@ -92,12 +92,9 @@ find "$SOURCE_BASE_DIR" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "
 
         # Create AVIF and WebP for the current size
         # We use > to ensure we don't upscale small images
-        avif_resize_cmd="magick \"$source_image_path\" -resize '${width}>' +profile \"*\" -quality $IM_AVIF_QUALITY \"$local_avif_path\""
-        webp_resize_cmd="magick \"$source_image_path\" -resize '${width}>' -quality $IM_WEBP_QUALITY \"$local_webp_path\""
-
         if [ "$DRY_RUN" = false ]; then
-            eval "$avif_resize_cmd"
-            eval "$webp_resize_cmd"
+            magick "$source_image_path" -resize "${width}>" +profile "*" -quality "$IM_AVIF_QUALITY" "$local_avif_path"
+            magick "$source_image_path" -resize "${width}>" -quality "$IM_WEBP_QUALITY" "$local_webp_path"
         fi
     done
     # --- END: NEW LOGIC ---


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection in `process_my_images.sh` where `eval` was used to execute a string containing unvalidated variable content (specifically image file paths).

⚠️ **Risk:** The potential impact if left unfixed is arbitrary code execution. An attacker who can influence the filenames of images being processed (e.g., by uploading a file with a malicious name) could execute arbitrary shell commands in the context of the user running the script.

🛡️ **Solution:** The fix eliminates the use of `eval` for responsive image generation. Instead, it invokes the `magick` command directly with all variables properly double-quoted. This ensures that the shell treats the variable contents as literal arguments rather than part of the command structure.

---
*PR created automatically by Jules for task [12027970290798398569](https://jules.google.com/task/12027970290798398569) started by @ryanofarrell*