### PR TITLE
🧹 Add aria-hidden on Decorative Icons

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,12 +28,12 @@ permalink: /contact/
             <div class="contact-info-block">
               <h4 class="mb-3">Contact Information</h4>
               <p>
-                <i class="fas fa-envelope text-primary mr-2"></i>
+                <i class="fas fa-envelope text-primary mr-2" aria-hidden="true"></i>
                 Email:
                 <a href="mailto:{{ site.email }}">{{ site.email }}</a>
               </p>
               <p>
-                <i class="fas fa-phone text-primary mr-2"></i>
+                <i class="fas fa-phone text-primary mr-2" aria-hidden="true"></i>
                 Phone:
                 <a href="tel:{{ site.phone-numeric }}">{{ site.phone-text }}</a>
               </p>

--- a/services.html
+++ b/services.html
@@ -155,7 +155,7 @@ permalink: /services/
                         {% if tier.standard_includes %}
                           {% for item in tier.standard_includes %}
                             <li>
-                              <i class="fas fa-check-circle text-primary mr-2"></i>
+                              <i class="fas fa-check-circle text-primary mr-2" aria-hidden="true"></i>
                               {{ item }}
                             </li>
                           {% endfor %}
@@ -163,7 +163,7 @@ permalink: /services/
                         {% if tier.additional_includes %}
                           {% for item in tier.additional_includes %}
                             <li class="additional-include">
-                              <i class="fas fa-check-circle text-success mr-2"></i>
+                              <i class="fas fa-check-circle text-success mr-2" aria-hidden="true"></i>
                               {{ item }}
                             </li>
                           {% endfor %}
@@ -203,7 +203,7 @@ permalink: /services/
                     <ul class="tier-includes-list">
                       {% for detail in offering.details_list %}
                         <li>
-                          <i class="fas fa-check-circle text-primary mr-2"></i>
+                          <i class="fas fa-check-circle text-primary mr-2" aria-hidden="true"></i>
                           {{ detail }}
                         </li>
                       {% endfor %}


### PR DESCRIPTION
Improved accessibility by adding `aria-hidden="true"` to decorative FontAwesome icons in `contact.html` and `services.html`. This ensures that screen readers do not announce these purely visual elements, adhering to WCAG guidelines and the project's accessibility best practices.

---
*PR created automatically by Jules for task [5387746642666020100](https://jules.google.com/task/5387746642666020100) started by @ryanofarrell*