### PR TITLE
UX: Add hover and focus states to carousel controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## Focus States and Colors
 - **Anti-Pattern:** Using hardcoded RGB or hex values (e.g., `rgba(254, 209, 55, 0.5)`) for `:focus` state `box-shadow` rules on interactive elements like buttons.
 - **Solution:** Use semantic color variables (e.g., `$primary`, `$secondary`, `$action`) within the `rgba()` function to ensure focus rings are dynamically consistent with the element's specific color variant.
+
+## Carousel Control Interactivity
+- **Anti-Pattern:** Carousel controls (e.g., directional arrows) lacking explicit, visible focus states and active hover states beyond browser defaults. This makes them hard to notice for keyboard users and provides poor visual feedback.
+- **Solution:** Apply a semantic `box-shadow` to `:focus` (while disabling `outline`), and implement subtle scale (`transform: scale()`) and color darkening transformations on `:hover` and `:focus` states.

--- a/_sass/layout/_testimonial.scss
+++ b/_sass/layout/_testimonial.scss
@@ -33,6 +33,19 @@
   .carousel-arrow {
     color: $primary;
     font-size: 50px;
+    transition: all 0.3s ease;
+    border-radius: 50%; /* Ensure round shape for focus ring */
+
+    &:hover,
+    &:focus {
+      color: darken($primary, 10%);
+      transform: scale(1.1);
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
+    }
   }
   .carousel-control {
     width: 10%;


### PR DESCRIPTION
This PR introduces an accessibility and usability micro-interaction to the testimonial carousel arrows. Previously, the arrows lacked explicit hover or visible focus states beyond the browser defaults. This change implements a custom focus ring, subtle scaling, and color transitions to improve feedback for mouse and keyboard users alike.

The new pattern has been documented in `.Jules/palette.md` to prevent this anti-pattern in the future.

---
*PR created automatically by Jules for task [4376174498628058014](https://jules.google.com/task/4376174498628058014) started by @ryanofarrell*