### PR TITLE
Optimize site CSS build using correct PurgeCSS targeting

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -2,9 +2,7 @@
 module.exports = {
   content: ["_site/**/*.html", "_site/**/*.js"],
   css: [
-    "_site/assets/css/agency.css",
-    "_site/assets/css/bootstrap.min.css",
-    "_site/assets/css/all.min.css",
+    "_site/assets/css/*.css",
   ],
   // Add this safelist to protect dynamic classes
   safelist: ["show", "collapse", "collapsing", "navbar-shrink", "active"],


### PR DESCRIPTION
Addresses the unused CSS bloat in the static site build. Previously, `purgecss.config.js` incorrectly targeted non-existent standalone files for `bootstrap.min.css` and `all.min.css` because they were natively compiled directly into `agency.css`. By updating the config to use a glob pattern, PurgeCSS will properly remove all unused library and template classes from the actual compiled stylesheet.

---
*PR created automatically by Jules for task [6098487962732113407](https://jules.google.com/task/6098487962732113407) started by @ryanofarrell*