### PR TITLE
Add new blog post for 6-9 month wake windows

### DIFF
--- a/_posts/2024-06-20-wake-windows-6-9-months.md
+++ b/_posts/2024-06-20-wake-windows-6-9-months.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: How to fill Wake Windows 6-9 Months
+date: 2024-06-20 00:00:00 -0400
+categories: posts
+excerpt: Mastering wake windows with your 6-9 month old? Discover engaging, OT-approved activities to foster development during this busy stage, from crawling prep to messy meals.
+classes: wide
+tag: Posts
+concepts: ["infant activities", "wake windows", "crawling", "sitting", "fine motor", "sensory play"]
+# header:
+#     teaser:
+# image:
+
+---
+
+_For 3-6 months [click here](wake-windows-3-6-months)_
+
+The 6-9 month phase is an incredibly busy and exciting time! Your little one is likely sitting up independently, starting to become mobile, and trying solid foods for the first time. They are gaining so much independence and curiosity about the world around them. As an OT mom, watching this explosion of motor and cognitive skills is thrilling, but it also means those wake windows are getting longer and require more active engagement to keep them busy (and out of trouble!).
+
+Here are some of my favorite ways to facilitate development and fill wake windows for 6-9 month olds!
+
+## 1. Couch Cushion Obstacle Courses
+Once your baby is sitting independently and starting to get on their hands and knees, it's time to encourage crawling! A great way to build the core and shoulder strength needed for this milestone is by creating safe, soft obstacles. I love taking the cushions off the couch and placing them on the floor. Encourage your baby to reach for a favorite toy placed just out of reach over a cushion. This encourages them to shift their weight, get on their knees, and problem-solve how to move their body over uneven surfaces.
+
+## 2. Messy Sensory Meals
+At 6 months, we start introducing solids, which is one of the best sensory experiences you can provide! Whether you choose purees or baby-led weaning, let it be messy. Allow your baby to smear food on their tray, squish it in their hands, and bring it to their mouth. This tactile play is crucial for decreasing tactile defensiveness and laying the foundation for fine motor skills. Strip them down to a diaper, embrace the mess, and remember that playing with food *is* learning!
+
+## 3. Container Play (Put In, Take Out)
+Right around 8-9 months, babies start to understand cause and effect and spatial relationships. They love taking things out of containers and, eventually, putting them back in. You don't need fancy toys for this! A clean, empty tissue box or an old wipes container filled with small, safe items (like baby washcloths, large blocks, or even clean socks) works perfectly. This activity works on their emerging pincer grasp (using the thumb and index finger) and visual-motor integration.
+
+## 4. Heavy Work for Better Sleep
+As wake windows get longer (often stretching to 2.5-3 hours), babies need ample physical activity to build sleep pressure. In the OT world, we call this "heavy work"—activities that provide deep proprioceptive input to the muscles and joints. Pushing a heavy laundry basket across the floor, crawling over pillows, or playing "horsey" on your knee provides organizing input that helps calm the nervous system and prepare them for a good nap.
+
+## 5. Water Play in the High Chair
+The witching hour is still very real at this age, especially as you drop down to two naps. When my little one is fussy in the late afternoon, I strap her into her high chair and put a shallow baking sheet of water with a few floating toys or ice cubes on the tray. It contains the mess, provides an engaging sensory experience, and buys me 15 minutes to prep dinner. The splashing also provides great tactile and auditory feedback!
+
+## 6. Supported Standing and Cruising
+Towards the end of this window, your baby might start pulling up to stand. You can encourage this by placing highly motivating toys on low, stable surfaces like an ottoman, a sturdy coffee table, or the couch. Playing in a supported standing position strengthens their legs and hips and prepares them for cruising and, eventually, walking. Always stay close to catch them as they learn to balance!
+
+Every baby develops at their own pace, so follow your little one's lead and have fun exploring this active new stage together!


### PR DESCRIPTION
As "Ink", identified a content gap in the "Wake Windows" series (existing posts covered 0-3 and 3-6 months). Added a new post for 6-9 months using the empathetic OT-mom voice, maintaining all constraints (IMAGE FREEZE front matter rules).

---
*PR created automatically by Jules for task [9191043159665648642](https://jules.google.com/task/9191043159665648642) started by @ryanofarrell*