### PR TITLE
Add soft hooks to meet-maria and services pages

### DIFF
--- a/meet-maria.html
+++ b/meet-maria.html
@@ -75,3 +75,5 @@ permalink: /meet-maria/
     </div>
   </div>
 </section>
+
+{% include soft_hook.html title="Get to know me better" text="Follow along on Instagram for daily OT tips, behind-the-scenes moments, and playful activities." btn_text="Follow on Instagram" btn_link="https://www.instagram.com/playfulprogressions/" external=true %}

--- a/services.html
+++ b/services.html
@@ -298,3 +298,5 @@ permalink: /services/
 
   </div>
 </section>
+
+{% include soft_hook.html title="Looking for free resources?" text="Check out our blog for expert articles on child development, occupational therapy activities, and parenting tips." btn_text="Read the Blog" btn_link="/blog/" %}


### PR DESCRIPTION
Add soft hooks to the bottom of the `meet-maria.html` and `services.html` pages to prevent user dead ends, aligning with the "Convert" engagement strategy.
- In `meet-maria.html`, added an Instagram follow prompt to encourage ongoing engagement.
- In `services.html`, added a link to the blog to provide free resources and keep users on the site.

---
*PR created automatically by Jules for task [9320990659361703631](https://jules.google.com/task/9320990659361703631) started by @ryanofarrell*