### PR TITLE
Enhance Schema.org Metadata with medicalSpecialty

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -43,18 +43,18 @@
       "@context": "https://schema.org",
       "@type": "MedicalBusiness",
       "name": {{ site.name | jsonify }},
-      "medicalSpecialty": "OccupationalTherapy",
-      "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
-      "url": {{ site.url | jsonify }},
-      "logo": {{ site.logo | prepend: site.url | jsonify }},
+      "medicalSpecialty": "https://schema.org/OccupationalTherapy",
       "telephone": {{ site.phone-numeric | jsonify }},
-      "image": "{{ sitetext.team.people[0].image | prepend: site.url }}",
       "address": {
         "@type": "PostalAddress",
         "addressLocality": "Atlanta",
         "addressRegion": "GA",
         "addressCountry": "US"
       },
+      "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
+      "url": {{ site.url | jsonify }},
+      "logo": {{ site.logo | prepend: site.url | jsonify }},
+      "image": "{{ sitetext.team.people[0].image | prepend: site.url }}",
       "areaServed": [
         {%- for neighborhood in sitetext.location_info.neighborhoods -%}
           {

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -43,6 +43,7 @@
       "@context": "https://schema.org",
       "@type": "MedicalBusiness",
       "name": {{ site.name | jsonify }},
+      "medicalSpecialty": "OccupationalTherapy",
       "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
       "url": {{ site.url | jsonify }},
       "logo": {{ site.logo | prepend: site.url | jsonify }},


### PR DESCRIPTION
Adds the `"medicalSpecialty": "OccupationalTherapy"` property to the `MedicalBusiness` Schema.org definition in `_includes/head/custom.html` to improve local SEO and clarify business offerings for search engines.

---
*PR created automatically by Jules for task [10456390259526388872](https://jules.google.com/task/10456390259526388872) started by @ryanofarrell*