### PR TITLE
Enhance MedicalBusiness Schema with occupational therapy specialty

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -42,6 +42,7 @@
     {
       "@context": "https://schema.org",
       "@type": "MedicalBusiness",
+      "medicalSpecialty": "https://schema.org/OccupationalTherapy",
       "name": {{ site.name | jsonify }},
       "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
       "url": {{ site.url | jsonify }},

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -42,7 +42,10 @@
     {
       "@context": "https://schema.org",
       "@type": "MedicalBusiness",
-      "medicalSpecialty": "https://schema.org/OccupationalTherapy",
+      "medicalSpecialty": [
+        "https://schema.org/OccupationalTherapy",
+        "https://schema.org/Pediatric"
+      ],
       "name": {{ site.name | jsonify }},
       "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
       "url": {{ site.url | jsonify }},


### PR DESCRIPTION
Adds the "medicalSpecialty" property explicitly defined as "OccupationalTherapy" using the schema.org URL to the `MedicalBusiness` JSON-LD object in the global site `<head>`. This directly aligns with local SEO goals, increasing information scent so search engines better understand the precise type of medical services offered, without requiring any visible UI changes or permalink alterations.

---
*PR created automatically by Jules for task [17614664079398370122](https://jules.google.com/task/17614664079398370122) started by @ryanofarrell*