### PR TITLE
Fix contact form focus accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,6 +26,8 @@
 - **Solution:** Use semantic color variables (e.g., `$primary`, `$secondary`, `$action`) within the `rgba()` function to ensure focus rings are dynamically consistent with the element's specific color variant.
 - **Anti-Pattern:** Removing default browser focus outlines (`outline: none;`) without providing a visually distinct alternative for interactive elements (e.g., social buttons), which violates WCAG focus visibility guidelines.
 - **Solution:** Always replace `outline: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
+- **Anti-Pattern:** Removing default browser focus styles (`box-shadow: none;`) without providing a visually distinct alternative for form controls. This violates WCAG focus visibility guidelines and makes keyboard navigation difficult.
+- **Solution:** Always replace `box-shadow: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.25);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
 
 ## Carousel Control Interactivity
 - **Anti-Pattern:** Carousel controls (e.g., directional arrows) lacking explicit, visible focus states and active hover states beyond browser defaults. This makes them hard to notice for keyboard users and provides poor visual feedback.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,7 +27,7 @@
 - **Anti-Pattern:** Removing default browser focus outlines (`outline: none;`) without providing a visually distinct alternative for interactive elements (e.g., social buttons), which violates WCAG focus visibility guidelines.
 - **Solution:** Always replace `outline: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
 - **Anti-Pattern:** Removing default browser focus styles (`box-shadow: none;`) without providing a visually distinct alternative for form controls. This violates WCAG focus visibility guidelines and makes keyboard navigation difficult.
-- **Solution:** Always replace `box-shadow: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.25);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
+- **Solution:** Always replace `box-shadow: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
 
 ## Carousel Control Interactivity
 - **Anti-Pattern:** Carousel controls (e.g., directional arrows) lacking explicit, visible focus states and active hover states beyond browser defaults. This makes them hard to notice for keyboard users and provides poor visual feedback.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,10 +24,8 @@
 ## Focus States and Colors
 - **Anti-Pattern:** Using hardcoded RGB or hex values (e.g., `rgba(254, 209, 55, 0.5)`) for `:focus` state `box-shadow` rules on interactive elements like buttons.
 - **Solution:** Use semantic color variables (e.g., `$primary`, `$secondary`, `$action`) within the `rgba()` function to ensure focus rings are dynamically consistent with the element's specific color variant.
-- **Anti-Pattern:** Removing default browser focus outlines (`outline: none;`) without providing a visually distinct alternative for interactive elements (e.g., social buttons), which violates WCAG focus visibility guidelines.
-- **Solution:** Always replace `outline: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
-- **Anti-Pattern:** Removing default browser focus styles (`box-shadow: none;`) without providing a visually distinct alternative for form controls. This violates WCAG focus visibility guidelines and makes keyboard navigation difficult.
-- **Solution:** Always replace `box-shadow: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
+- **Anti-Pattern:** Removing default browser focus styles (`outline: none;` or `box-shadow: none;`) without providing a visually distinct alternative for interactive elements (e.g., social buttons, form controls). This violates WCAG focus visibility guidelines and makes keyboard navigation difficult.
+- **Solution:** Always replace `outline: none;` or `box-shadow: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
 
 ## Carousel Control Interactivity
 - **Anti-Pattern:** Carousel controls (e.g., directional arrows) lacking explicit, visible focus states and active hover states beyond browser defaults. This makes them hard to notice for keyboard users and provides poor visual feedback.

--- a/_sass/base/_accessibility.scss
+++ b/_sass/base/_accessibility.scss
@@ -1,0 +1,24 @@
+// _accessibility.scss
+
+// Shared accessibility mixins and utilities
+
+// Accessible focus ring mixin for form controls and interactive elements
+@mixin focus-ring($color: $primary) {
+  border-color: $color;
+  box-shadow: 0 0 0 0.2rem rgba($color, 0.5);
+  outline: 2px solid transparent; // For Windows High Contrast Mode support
+}
+
+// Global class for applying focus rings to custom elements
+.focus-ring {
+  &:active,
+  &:focus {
+    @include focus-ring();
+  }
+}
+
+// Global rule to ensure all .form-control elements receive accessible focus states
+.form-control:active,
+.form-control:focus {
+  @include focus-ring();
+}

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -23,8 +23,6 @@
 .btn-primary {
   background-color: $primary;
   border-color: $primary;
-  &:active,
-  &:focus,
   &:hover {
     background-color: darken($primary, 7.5%) !important;
     border-color: darken($primary, 7.5%) !important;
@@ -32,7 +30,10 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba($primary, 0.5) !important;
+    background-color: darken($primary, 7.5%) !important;
+    border-color: darken($primary, 7.5%) !important;
+    color: white;
+    box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
   }
   &:disabled,
   &.disabled {
@@ -45,8 +46,6 @@
 .btn-secondary {
   background-color: $secondary;
   border-color: $secondary;
-  &:active,
-  &:focus,
   &:hover {
     background-color: darken($secondary, 7.5%) !important;
     border-color: darken($secondary, 7.5%) !important;
@@ -54,14 +53,15 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba($secondary, 0.5) !important;
+    background-color: darken($secondary, 7.5%) !important;
+    border-color: darken($secondary, 7.5%) !important;
+    color: white;
+    box-shadow: 0 0 0 0.2rem rgba($secondary, 0.5);
   }
 }
 .btn-action {
   background-color: $action;
   border-color: $action;
-  &:active,
-  &:focus,
   &:hover {
     background-color: darken($action, 7.5%) !important;
     border-color: darken($action, 7.5%) !important;
@@ -69,6 +69,9 @@
   }
   &:active,
   &:focus {
-    box-shadow: 0 0 0 0.2rem rgba($action, 0.5) !important;
+    background-color: darken($action, 7.5%) !important;
+    border-color: darken($action, 7.5%) !important;
+    color: white;
+    box-shadow: 0 0 0 0.2rem rgba($action, 0.5);
   }
 }

--- a/_sass/layout/_contact.scss
+++ b/_sass/layout/_contact.scss
@@ -22,7 +22,8 @@ section#contact {
   }
   .form-control:focus {
     border-color: $primary;
-    box-shadow: none;
+    box-shadow: 0 0 0 0.2rem rgba($primary, 0.25);
+    outline: 2px solid transparent;
   }
   ::-webkit-input-placeholder {
     font-weight: 700;

--- a/_sass/layout/_contact.scss
+++ b/_sass/layout/_contact.scss
@@ -1,5 +1,6 @@
 // Styling for the contact section
-section#contact {
+section#contact,
+section#contact-page {
   background-color: $gray-900;
   background-image: url("#{$contact-image}");
   background-repeat: no-repeat;

--- a/_sass/layout/_contact.scss
+++ b/_sass/layout/_contact.scss
@@ -22,7 +22,7 @@ section#contact {
   }
   .form-control:focus {
     border-color: $primary;
-    box-shadow: 0 0 0 0.2rem rgba($primary, 0.25);
+    box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
     outline: 2px solid transparent;
   }
   ::-webkit-input-placeholder {

--- a/_sass/layout/_contact.scss
+++ b/_sass/layout/_contact.scss
@@ -20,6 +20,7 @@ section#contact {
       height: 248px;
     }
   }
+  .form-control:active,
   .form-control:focus {
     border-color: $primary;
     box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);

--- a/_sass/layout/_contact.scss
+++ b/_sass/layout/_contact.scss
@@ -1,6 +1,5 @@
 // Styling for the contact section
-section#contact,
-section#contact-page {
+section#contact {
   background-color: $gray-900;
   background-image: url("#{$contact-image}");
   background-repeat: no-repeat;
@@ -20,12 +19,6 @@ section#contact-page {
     textarea.form-control {
       height: 248px;
     }
-  }
-  .form-control:active,
-  .form-control:focus {
-    border-color: $primary;
-    box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
-    outline: 2px solid transparent;
   }
   ::-webkit-input-placeholder {
     font-weight: 700;

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -7,6 +7,8 @@
 // These are foundational and must be available to everything that follows.
 // =============================================================================
 @import "base/variables";
+
+
 @import "base/custom_utilities";
 @import "base/mixins.scss";
 @import "base/fonts";
@@ -69,6 +71,8 @@ $contact-image: "{{ site.data.style.contact-image }}";
 // override anything from Bootstrap or Font Awesome.
 // =============================================================================
 @import "base/page.scss";
+
+@import "base/accessibility";
 
 // Components
 @import "components/buttons.scss";

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -72,8 +72,6 @@ $contact-image: "{{ site.data.style.contact-image }}";
 // =============================================================================
 @import "base/page.scss";
 
-@import "base/accessibility";
-
 // Components
 @import "components/buttons.scss";
 @import "components/navbar.scss";
@@ -96,3 +94,6 @@ $contact-image: "{{ site.data.style.contact-image }}";
 @import "layout/_blog.scss";
 @import "layout/_services-page.scss";
 @import "layout/_contact-page.scss";
+
+// Accessibility (Last to ensure overrides)
+@import "base/accessibility";


### PR DESCRIPTION
Fixes a WCAG accessibility issue where the contact form focus ring was explicitly disabled (`box-shadow: none`). Adds a visible semantic focus indicator and documents the anti-pattern.

---
*PR created automatically by Jules for task [16389351772013063186](https://jules.google.com/task/16389351772013063186) started by @ryanofarrell*