### PR TITLE
feat: add engagement soft hooks to prevent dead ends

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,3 +11,5 @@ layout: default
 <div class="container" id="pagecontainer">
   {{ content }}
 </div>
+
+{% include soft_hook.html title="Looking for more?" text="Explore our services or check out our latest blog posts." btn_text="View Services" btn_link="/services/" %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -41,4 +41,6 @@ layout: default
   </div>
 </article>
 
+{% include soft_hook.html title="Looking for more?" text="Explore our services or check out our latest blog posts." btn_text="View Services" btn_link="/services/" %}
+
 {% comment %} Add comments section or related posts here if desired {% endcomment %}

--- a/faq.html
+++ b/faq.html
@@ -30,17 +30,9 @@ permalink: /faq/
 
       {% comment %} Add more FAQ items here as needed in the data file {% endcomment %}
 
-      <div class="row mt-5">
-        <div class="col-lg-8 mx-auto text-center">
-          <div class="bg-light p-5 rounded">
-            <h3 class="section-heading mb-3">Still Have Questions?</h3>
-            <p class="text-muted mb-4">We're here to help! Reach out to us directly for more information or specific inquiries.</p>
-            <a class="btn btn-primary btn-xl text-uppercase" href="{{ '/contact/' | relative_url }}">Contact Us</a>
-          </div>
-        </div>
-      </div>
-
       </div>
     </div>
   </div>
 </section>
+
+{% include soft_hook.html title="Still Have Questions?" text="We're here to help! Reach out to us directly for more information or specific inquiries." btn_text="Contact Us" btn_link="/contact/" %}

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -43,3 +43,5 @@ permalink: /privacy-policy/
     </div>
   </div>
 </section>
+
+{% include soft_hook.html title="Back to the fun stuff?" text="Now that the legalities are out of the way, let's get back to playful development." btn_text="Read the Blog" btn_link="/blog/" %}


### PR DESCRIPTION
As requested, implemented "Soft Hooks" at the bottom of standard pages to prevent user dead ends. The solution introduces a reusable `soft_hook.html` include with customizable parameters for text and buttons. It has been integrated into the FAQ, Privacy Policy, and fallback `page` and `single` layouts. No scheduling tools are used, maintaining a low-pressure, mobile-first approach.

---
*PR created automatically by Jules for task [11472076420138211325](https://jules.google.com/task/11472076420138211325) started by @ryanofarrell*