### PR TITLE
UX: Add missing focus states to navbar and aria-hidden to icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,6 +27,9 @@
 - **Anti-Pattern:** Removing default browser focus outlines (`outline: none;`) without providing a visually distinct alternative for interactive elements (e.g., social buttons), which violates WCAG focus visibility guidelines.
 - **Solution:** Always replace `outline: none;` with a clear focus indicator, such as a `box-shadow` using semantic variables (e.g., `box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);`). To support Windows High Contrast Mode, also include a transparent outline (e.g., `outline: 2px solid transparent;`).
 
+- **Anti-Pattern:** Applying color transitions or transformations exclusively to `:hover` and `.active` states on interactive elements (like navigation links or custom icons), while completely omitting the `:focus` state.
+- **Solution:** Always pair `:focus` with `:hover` (e.g., `&:hover, &:focus { color: $action; }`) when defining interactive visual feedback to ensure keyboard users experience the same visual context as pointer users.
+
 ## Carousel Control Interactivity
 - **Anti-Pattern:** Carousel controls (e.g., directional arrows) lacking explicit, visible focus states and active hover states beyond browser defaults. This makes them hard to notice for keyboard users and provides poor visual feedback.
 - **Solution:** Apply a semantic `box-shadow` to `:focus` (while disabling `outline`), and implement subtle scale (`transform: scale()`) and color darkening transformations on `:hover` and `:focus` states.

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -52,7 +52,7 @@
             {% if icon.type == "instagram" %}
             target="_blank" rel="noopener noreferrer"
             {% endif %}>
-            <i class="{{ icon.icon }}"></i>
+            <i class="{{ icon.icon }}" aria-hidden="true"></i>
           </a>
         {% endfor %}
       </div>
@@ -99,7 +99,7 @@
               {% if icon.type == "instagram" %}
               target="_blank" rel="noopener noreferrer"
               {% endif %}>
-              <i class="{{ icon.icon }}"></i>
+              <i class="{{ icon.icon }}" aria-hidden="true"></i>
             </a>
           {% endfor %}
         </li>

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -30,9 +30,13 @@
     margin-bottom: 5px; /* Space below the toggler */
     width: 120px; /* Adjust this value as needed */
     // Add hover/focus styles for toggler on mobile if desired
-    &:hover,
+    &:hover {
+      color: white; /* Example: Primary color on hover/focus */
+    }
     &:focus {
       color: white; /* Example: Primary color on hover/focus */
+      outline: 2px solid transparent;
+      box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
     }
   }
 
@@ -68,7 +72,8 @@
       .nav-link {
         /* Generic nav-link styles */
         &.active,
-        &:hover {
+        &:hover,
+        &:focus {
           color: $action; /* Default active/hover color */
         }
       }
@@ -175,7 +180,8 @@
           /* Generic nav-link style for desktop */
           color: white; /* Desktop: white link text on dark headers */
           &.active,
-          &:hover {
+          &:hover,
+          &:focus {
             color: $action; /* Active/hover color */
           }
         }
@@ -221,7 +227,8 @@
             .nav-link {
               color: $gray-900; /* Shrunk: dark grey link color */
               &.active,
-              &:hover {
+              &:hover,
+              &:focus {
                 color: $action;
               }
             }
@@ -244,7 +251,8 @@
         /* Contact icon color when navbar is shrunk (on dark header) */
         .contact-icon {
           color: $gray-300; /* Light grey color when shrunk on dark */
-          &:hover {
+          &:hover,
+          &:focus {
             color: $action;
           }
         }
@@ -280,7 +288,8 @@
             /* Generic nav-link style on light background (desktop) */
             color: $primary;
             &.active,
-            &:hover {
+            &:hover,
+            &:focus {
               color: $action;
             }
           }
@@ -294,7 +303,8 @@
         }
         .contact-icon {
           color: $primary; /* Primary icon color on light background */
-          &:hover {
+          &:hover,
+          &:focus {
             color: darken($primary, 10%); /* Hover effect */
           }
         }
@@ -306,7 +316,8 @@
   /* This applies to mobile icons on dark header BEFORE scrolling */
   .contact-icon {
     color: $primary; /* Changed default color to primary */
-    &:hover {
+    &:hover,
+    &:focus {
       color: darken($primary, 10%); /* Hover effect */
     }
   }

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -30,11 +30,11 @@
     margin-bottom: 5px; /* Space below the toggler */
     width: 120px; /* Adjust this value as needed */
     // Add hover/focus styles for toggler on mobile if desired
-    &:hover {
+    &:hover,
+    &:focus {
       color: white; /* Example: Primary color on hover/focus */
     }
     &:focus {
-      color: white; /* Example: Primary color on hover/focus */
       outline: 2px solid transparent;
       box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
     }

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -30,11 +30,13 @@
     margin-bottom: 5px; /* Space below the toggler */
     width: 120px; /* Adjust this value as needed */
     // Add hover/focus styles for toggler on mobile if desired
-    &:hover,
-    &:focus {
+    &:hover {
       color: white; /* Example: Primary color on hover/focus */
+    }
+    &:focus {
+      color: white;
       outline: 2px solid transparent;
-      box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
+      box-shadow: 0 0 0 0.2rem rgba($action, 0.5);
     }
   }
 

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -30,11 +30,11 @@
     margin-bottom: 5px; /* Space below the toggler */
     width: 120px; /* Adjust this value as needed */
     // Add hover/focus styles for toggler on mobile if desired
-    &:hover {
-      color: white; /* Example: Primary color on hover/focus */
-    }
+    &:hover,
     &:focus {
       color: white;
+    }
+    &:focus {
       outline: 2px solid transparent;
       box-shadow: 0 0 0 0.2rem rgba($action, 0.5);
     }

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -33,8 +33,6 @@
     &:hover,
     &:focus {
       color: white; /* Example: Primary color on hover/focus */
-    }
-    &:focus {
       outline: 2px solid transparent;
       box-shadow: 0 0 0 0.2rem rgba($primary, 0.5);
     }


### PR DESCRIPTION
Adds missing focus states to navbar elements for improved accessibility and includes `aria-hidden="true"` on decorative navigation icons. Also documents this in the `.Jules/palette.md` UX journal.

---
*PR created automatically by Jules for task [14716272990235189302](https://jules.google.com/task/14716272990235189302) started by @ryanofarrell*