### PR TITLE
🧹 Remove redundant commented-out URL building logic in contact_me.js

### DIFF
--- a/assets/js/contact_me.js
+++ b/assets/js/contact_me.js
@@ -16,7 +16,6 @@ $(function () {
       event.preventDefault(); // Prevent default submit behaviour (already done by preventSubmit: true, but good to keep)
 
       // Get values from FORM
-      // var url = "https://formspree.io/" + "{% if site.formspree_form_path %}{{ site.formspree_form_path }}{% else %}{{ site.email }}{% endif %}"; // Removed this line
       var url = $form.attr("action"); // Get the submission URL directly from the form's action attribute
 
       // Basic URL validation: Ensure it starts with the expected Formspree prefix


### PR DESCRIPTION
### 🎯 What: 
Removed the commented-out legacy URL building logic in `assets/js/contact_me.js` that used Liquid template tags.

### 💡 Why:
The code was already replaced by a more robust method of fetching the submission URL directly from the form's `action` attribute. Removing the dead code reduces clutter and improves the maintainability of the JavaScript file.

### ✅ Verification:
- Verified via `grep` that the line is successfully removed.
- Confirmed the active code (`var url = $form.attr("action");`) remains intact and correctly positioned.
- Ran existing unit tests for `name_utils.js` to ensure no regressions in related form processing logic.
- Obtained a positive code review confirming the change is safe and follows best practices.

### ✨ Result:
Cleaner and more readable `contact_me.js` file.

---
*PR created automatically by Jules for task [4177722012199602764](https://jules.google.com/task/4177722012199602764) started by @ryanofarrell*