### PR TITLE
🧹 remove unused os and signal imports in verify_images_server.py

### DIFF
--- a/verify_images_server.py
+++ b/verify_images_server.py
@@ -1,7 +1,5 @@
 import subprocess
 import time
-import os
-import signal
 from playwright.sync_api import sync_playwright
 
 def run():


### PR DESCRIPTION
🎯 **What:** Removed unused `os` and `signal` imports from `verify_images_server.py`.
💡 **Why:** Removing unused imports reduces noise and improves code maintainability and readability by keeping the dependency list accurate.
✅ **Verification:** Verified the file content and ran `python3 -m py_compile verify_images_server.py` to ensure no syntax errors were introduced. Also received a positive code review.
✨ **Result:** A cleaner and more maintainable `verify_images_server.py` file.

---
*PR created automatically by Jules for task [13715619345483708819](https://jules.google.com/task/13715619345483708819) started by @ryanofarrell*