### PR TITLE
Add blog post for 6-9 months wake windows

### DIFF
--- a/_posts/2026-05-06-wake-windows-6-9-months.md
+++ b/_posts/2026-05-06-wake-windows-6-9-months.md
@@ -1,0 +1,54 @@
+---
+layout: post
+title: How to fill Wake Windows 6-9 Months
+date: 2026-05-06 08:03:00 -0400
+categories: posts
+excerpt: "Your baby is on the move! As wake windows stretch to 2-3 hours, discover OT-approved activities like container play, safe obstacle courses, and taste-safe sensory bins to keep your 6-9 month old engaged and developing."
+classes: wide
+tag: Posts
+concepts: ["wake windows", "infant activities", "crawling", "container play", "sensory bins", "fine motor skills"]
+# header:
+#     teaser: /assets/images/processed/blog/wake-windows-6-9.jpeg
+# image: /assets/images/processed/blog/wake-windows-6-9.jpeg
+---
+
+_For 3-6 months [click here](wake-windows-3-6-months)_
+
+Welcome to the busy phase! Between 6 and 9 months, your baby's wake windows are lengthening (usually around 2 to 3 hours), and they are likely becoming much more mobile. They might be sitting independently, combat crawling, or even pulling to stand! With longer awake times and new physical abilities, keeping them entertained can feel like a full-time job. Here are some of my favorite OT-approved ways to fill those wake windows while supporting their rapidly developing skills.
+
+## 1. Container Play
+
+Now that your baby might be sitting more confidently, it's the perfect time to introduce container play! This simply means putting objects into a container and taking them out again. It sounds basic, but it's a huge developmental milestone for fine motor skills and cognitive development (understanding cause and effect, and object permanence).
+
+*   **How to do it:** Use a clean, empty wipes container, an oatmeal canister with a hole cut in the lid, or just a simple bowl. Provide safe, graspable items like blocks, large wooden beads, or even rolled-up pairs of socks.
+*   **The OT benefit:** This activity encourages the development of voluntary release (letting go of an object on purpose), improves hand-eye coordination, and refines their grasp as they learn to pick up items of different shapes and sizes.
+
+## 2. Taste-Safe Sensory Bins
+
+By 6 months, babies are exploring the world mouth-first. Because everything goes straight to the mouth, traditional sensory bins with water beads or small beans aren't safe yet. Enter the taste-safe sensory bin!
+
+*   **How to do it:** Blend plain cheerios or graham crackers into "sand," cook up some plain pasta, or use water with a little bit of food coloring. Place the filler in a shallow bin or baking dish, add some cups, spoons, or small toys, and let them explore. (Always supervise closely!)
+*   **The OT benefit:** Sensory bins provide rich tactile input, which is essential for brain development. Exploring different textures with their hands (and mouths) helps desensitize their tactile system, which can be incredibly helpful when introducing new food textures during mealtime.
+
+## 3. The "Couch Cushion" Obstacle Course
+
+If your baby is starting to army crawl or get up on their hands and knees, it's time to encourage that movement!
+
+*   **How to do it:** Take the cushions off the couch and lay them on the floor to create uneven surfaces, small "mountains" to climb over, or little tunnels to crawl through (using a blanket draped over two chairs).
+*   **The OT benefit:** Crawling over uneven surfaces is fantastic for building core strength, shoulder stability, and bilateral coordination (using both sides of the body together). It also provides deep proprioceptive input to their joints, which is calming and organizing for their nervous system.
+
+## 4. Supported Standing and Reaching
+
+As babies approach 9 months, many become very interested in pulling themselves up. We can support this transition safely.
+
+*   **How to do it:** Place highly desired toys on the seat of the couch or a low, sturdy coffee table. Support your baby at their hips (not by pulling their arms) as they practice pulling to a stand or weight-bearing on their legs while leaning against the surface.
+*   **The OT benefit:** This encourages weight shifting, builds lower extremity and core strength, and promotes balance. Reaching for toys while standing requires complex weight-shifting and postural control.
+
+## 5. Reading with Interactive Books
+
+Reading is always a great way to fill time, but at this age, babies want to be involved. They aren't just passively listening anymore!
+
+*   **How to do it:** Choose sturdy board books with different textures (like the "That's Not My..." series), lift-the-flap books, or books with mirrors. Encourage your baby to help turn the pages.
+*   **The OT benefit:** Turning thick board book pages is a great way to practice isolating the index finger and using a pincer grasp. Books with textures provide tactile input, and pointing out pictures helps develop joint attention—a crucial early communication skill.
+
+The 6-9 month window is so much fun because they are learning to actively participate in play. Remember, the goal isn't to rigidly schedule every minute of their day, but to have a few go-to activities in your back pocket when you hear yourself thinking, "What are we going to do until nap time?!"


### PR DESCRIPTION
Identified a narrative gap in the "wake windows" blog series (which stopped at 6 months) and drafted a new post for the 6-9 months range. The post follows the requested OT-Mom voice, utilizes appropriate H2 structures for activities like Container Play and Sensory Bins, and strictly adheres to the IMAGE FREEZE constraint by leaving front matter image fields commented out. Date is set correctly so the post is visible.

---
*PR created automatically by Jules for task [5802756627531351422](https://jules.google.com/task/5802756627531351422) started by @ryanofarrell*