### PR TITLE
Add 6-9 month wake windows blog post

### DIFF
--- a/_posts/2026-05-13-wake-windows-6-9-months.md
+++ b/_posts/2026-05-13-wake-windows-6-9-months.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: How to fill Wake Windows 6-9 Months
+date: 2026-05-13 08:03:00 -0400
+categories: posts
+excerpt: Navigating the 6-9 month wake windows? It's a busy time! An OT mom shares practical, play-based ideas to encourage sitting, crawling, fine motor skills, and sensory exploration during these expanding awake periods.
+classes: wide
+tag: Posts
+concepts: ["infant activities", "wake windows", "crawling", "sitting", "fine motor", "sensory play"]
+# header:
+#     teaser: /assets/images/processed/blog/wake-windows-6-9.jpeg
+# image: /assets/images/processed/blog/wake-windows-6-9.jpeg
+---
+
+_For 0-3 months [click here](wake-windows-0-3-months)_
+_For 3-6 months [click here](wake-windows-3-6-months)_
+
+Wow, 6 to 9 months! This stage is a whirlwind. Suddenly, your baby is no longer just a spectator; they are an active participant in their environment. Wake windows stretch longer, usually to about 2 to 3 hours, meaning you have more time to fill, but also a more capable playmate!
+
+At this age, development is exploding. We are looking at mastering sitting, potentially the beginnings of crawling (or some very creative scooting!), and a huge leap in fine motor skills, like moving from a raking grasp to picking up smaller objects. They are also starting to understand cause and effect. It's so fun, but it can be exhausting trying to keep them entertained.
+
+Here are my favorite OT-approved ways to fill those 6-9 month wake windows, encouraging development without making you feel like a cruise ship director.
+
+## Gross Motor: Moving and Grooving
+
+This is the era of independent movement! Whether they are rolling with purpose, army crawling, or getting up on hands and knees, they want to go.
+
+### 1. The Obstacle Course (Baby Version)
+Once your baby is showing interest in moving, create safe challenges. Use couch cushions, pillows, or rolled-up blankets to create small hurdles on the floor. Place a favorite toy *just* out of reach over a cushion. This encourages them to problem-solve how to get over it, strengthening their core, arms, and legs. If they are getting up on hands and knees, this is great practice for shifting their weight.
+
+### 2. Supported Standing at Furniture
+Around 8-9 months, many babies love to pull up. Create safe spaces for this. Use a sturdy, low coffee table or the couch. Place engaging toys—like a busy board, suction cup spinners, or simply a favorite teething toy—on the surface to encourage them to reach and stand. *Always stay close by to catch them when they inevitably plop down!* This builds leg strength, core stability, and prepares them for cruising.
+
+### 3. Sitting Practice... with a Twist
+If they are still mastering sitting, provide support but challenge their balance gently. Sit behind them so you can catch them. Place toys in a semi-circle around them, encouraging them to reach across their body (crossing midline) or twist slightly to grab something. This dynamic sitting builds the core strength they need to sit independently and transition into a crawling position.
+
+## Fine Motor & Cognitive: Little Fingers, Big Brains
+
+They are moving from using their whole hand to grab things to using their thumb and fingers more deliberately. They are also figuring out *how* things work.
+
+### 4. Container Play (The Ultimate Hit)
+This is simple but holds their attention forever. Get a tupperware container, a small bucket, or an empty wipes dispenser. Give them smaller objects—blocks, large pompoms (monitor closely!), or even safe kitchen items like measuring spoons. Show them how to put the items *in* and take them *out*. This is huge for fine motor release (letting go of an object intentionally) and understanding object permanence.
+
+### 5. Water Play
+You don't need a pool; a shallow baking dish with a little water on the floor (put a towel down first!) or highchair tray is perfect. Add a few floating toys, cups for pouring, or sponges. Water play is fantastic sensory input. It encourages two-handed play (bilateral coordination) as they try to hold a cup and pour, and it's a great way to cool down or change the scenery if they are getting fussy. *Never leave them unattended with water, even a small amount.*
+
+### 6. Book Time - But Make It Interactive
+Reading is always great, but at this age, choose books they can interact with. Chunky board books, books with varied textures (like "That's Not My..."), or books with flaps. Let *them* try to turn the pages. It might be messy and they might just chew on the corner, but the act of manipulating the thick pages is excellent fine motor practice.
+
+## Sensory Play: Exploring the World
+
+Their sensory systems are hungry for new experiences.
+
+### 7. Food Exploration
+Since many babies start solids around 6 months, mealtime *is* sensory play! Let them touch the puree, smear the avocado, or hold the steamed carrot stick. Yes, it’s incredibly messy, but feeling the textures of food is vital for their tactile development and can help prevent picky eating later on. It’s hard, but try to embrace the mess during these wake windows!
+
+### 8. The "What's in the Bag?" Game
+Take a clean cloth bag or an opaque container. Put a few interesting, safe items inside: a smooth wooden spoon, a bumpy ball, a crinkly piece of paper (or safe fabric alternative). Let them reach in and feel the objects without seeing them first, then pull them out. This builds tactile discrimination—the ability to understand what you are touching without looking.
+
+## A Note for the OT Mom
+
+Remember, independent play is also a skill you can start fostering now. It’s okay if you aren’t actively entertaining them for every minute of a 3-hour wake window. Set up a safe space (like a playpen or gated area), scatter a few novel toys, and step back. Let them figure out how a toy works on their own.
+
+And lastly, if they are having an off day and just want to be held, that's okay too. Sometimes the best "activity" is just reading a book together on the couch. You are doing great!


### PR DESCRIPTION
Creates a new blog post filling the narrative gap between the existing 0-3 and 3-6 month wake window posts.

- File: `_posts/2026-05-13-wake-windows-6-9-months.md`
- Uses the "OT-Mom" empathetic and realistic voice.
- Includes clear H2 and H3 markdown tags for easy reading.
- Strictly adheres to the IMAGE FREEZE constraint by commenting out the `teaser` and `image` front-matter fields.
- Uses existing tags/categories.

---
*PR created automatically by Jules for task [2092181540273949747](https://jules.google.com/task/2092181540273949747) started by @ryanofarrell*