### PR TITLE
feat(seo): Expand MedicalBusiness Schema metadata

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -51,6 +51,8 @@
       "url": {{ site.url | jsonify }},
       "logo": {{ site.logo | prepend: site.url | jsonify }},
       "telephone": {{ site.phone-numeric | jsonify }},
+      "email": {{ site.email | jsonify }},
+      "paymentAccepted": "Credit Card, HSA, FSA",
       "image": "{{ sitetext.team.people[0].image | prepend: site.url }}",
       "address": {
         "@type": "PostalAddress",


### PR DESCRIPTION
This pull request updates the `MedicalBusiness` Schema.org JSON-LD metadata in `_includes/head/custom.html` to fully utilize available properties for better local SEO.

Specifically, it adds the `email` property (using `site.email`) and the `paymentAccepted` property (listing Credit Card, HSA, FSA as confirmed by the site's FAQ). This fulfills the user's request to make one meaningful adjustment to metadata to improve relevance.

---
*PR created automatically by Jules for task [15685547282318458692](https://jules.google.com/task/15685547282318458692) started by @ryanofarrell*