### PR TITLE
🎨 [a11y] Fix skip link focus management on main content

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -96,7 +96,7 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 **Instructions:** After auditing a file, mark it ✅ with the date. Pick the first unmarked file on each run.
 
 ### Layouts (`_layouts/`)
-- [ ] `default.html`
+- [✅] 2026-02-15 `default.html`
 - [ ] `home.html`
 - [ ] `post.html`
 - [ ] `page.html`
@@ -142,6 +142,12 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 ## Execution Log
 
 <!-- Palette's cumulative journal. New entries go at the top. -->
+
+### 2026-02-15 — Skip link focus management
+- **Target:** `_layouts/default.html`
+- **Finding:** The skip link targets `<main id="main-content">`, but without a `tabindex="-1"`, some browsers fail to properly shift programmatic focus to the element when activated.
+- **Action:** Added `tabindex="-1"` to `<main id="main-content">` to ensure reliable focus management for Keyboard-Only and Screen Reader users.
+- **Verification:** `bundle exec jekyll build` → ✅ Success
 
 ### 2026-02-14 — Focus states on custom icons
 - **Target:** `_sass/components/`, `_includes/navigation.html`

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
     {% include mini-masthead.html %}
   {% endif %}
 
-  <main id="main-content">
+  <main id="main-content" tabindex="-1">
     {{ content }}
   </main>
 


### PR DESCRIPTION
This pull request implements an accessibility improvement for the skip link functionality.

**What was wrong:**
The `.skip-link` targeted `<main id="main-content">`, but because the `<main>` element lacked a `tabindex` attribute, some browsers would not correctly shift the programmatic focus to it when the skip link was clicked. This meant that for keyboard and screen reader users, the next tab stop would incorrectly remain near the top of the page rather than jumping to the main content.

**What was changed:**
- Added `tabindex="-1"` to `<main id="main-content">` in `_layouts/default.html`. This allows the element to receive programmatic focus without adding it to the standard tab sequence.
- Updated `.Jules/palette.md` to check off `default.html` in the Coverage Tracker and appended a new entry detailing this fix to the Execution Log.

**Verification:**
- Verified the build succeeds with `bundle exec jekyll build`.
- The fix is fully contained within `_layouts/default.html` and does not introduce regressions or new issues.

---
*PR created automatically by Jules for task [2993809026317022769](https://jules.google.com/task/2993809026317022769) started by @ryanofarrell*