### PR TITLE
🔍 Add missing Schema.org properties to custom head

### DIFF
--- a/.Jules/search.md
+++ b/.Jules/search.md
@@ -135,7 +135,7 @@ done
 ## Coverage Tracker
 
 ### Schema.org Blocks
-- [ ] `_includes/head/custom.html` — Organization + LocalBusiness schema
+- [x] `_includes/head/custom.html` — Organization + LocalBusiness schema (2026-05-27)
 - [ ] `services.html` — Service + ItemList schema
 - [ ] `faq.html` — FAQPage schema (verify it exists or create)
 
@@ -165,5 +165,11 @@ done
 ## Execution Log
 
 <!-- Search's cumulative journal. New entries go at the top. -->
+
+## 2026-05-27 — Added missing Schema.org properties to custom head
+- **Target:** `_includes/head/custom.html`
+- **Finding:** The `MedicalBusiness` and `Article` > `Organization` schema blocks were missing required properties per the persona guidelines, including `paymentAccepted` and `areaServed`.
+- **Action:** Injected `email` and `paymentAccepted` into `MedicalBusiness`. Added `url`, `telephone`, `email`, `address`, `sameAs`, and `areaServed` to the `Organization` publisher object in the `Article` schema. Assigned `sitetext` globally.
+- **Verification:** `bundle exec jekyll build` → ✅ Success. Validated JSON output with custom python script.
 
 *No entries yet. First audit pending.*

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,3 +1,4 @@
+{%- assign sitetext = site.data.sitetext -%}
 {%- if page.layout == "post" -%}
   <script type="application/ld+json">
     {
@@ -29,6 +30,24 @@
           "publisher": {
             "@type": "Organization",
             "name": {{ site.name | jsonify }},
+            "url": {{ site.url | jsonify }},
+            "telephone": {{ site.phone-numeric | jsonify }},
+            "email": {{ site.email | jsonify }},
+            "address": {
+              "@type": "PostalAddress",
+              "addressLocality": "Atlanta",
+              "addressRegion": "GA",
+              "addressCountry": "US"
+            },
+            "sameAs": ["{{ site.instagram_url }}", "{{ site.google_business_url }}"],
+            "areaServed": [
+              {%- for neighborhood in sitetext.location_info.neighborhoods -%}
+                {
+                  "@type": "City",
+                  "name": {{ neighborhood | append: ", GA" | jsonify }}
+                }{%- unless forloop.last -%},{%- endunless -%}
+              {%- endfor -%}
+            ],
             "logo": {
               "@type": "ImageObject",
               "url": "{{ site.logo | relative_url | prepend: site.url }}"
@@ -37,7 +56,6 @@
         }
   </script>
 {%- else -%}
-  {%- assign sitetext = site.data.sitetext -%}
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -47,6 +65,9 @@
         "https://schema.org/Pediatric"
       ],
       "name": {{ site.name | jsonify }},
+      "email": {{ site.email | jsonify }},
+      "paymentAccepted": ["Credit Card", "HSA", "FSA"],
+      "priceRange": "$$",
       "description": {{ sitetext.about.body | strip_html | normalize_whitespace | jsonify }},
       "url": {{ site.url | jsonify }},
       "logo": {{ site.logo | prepend: site.url | jsonify }},


### PR DESCRIPTION
Injected missing properties into the Schema.org `MedicalBusiness` block (`email`, `paymentAccepted`, `priceRange`) and the `Article` `Organization` block (`url`, `telephone`, `email`, `address`, `sameAs`, `areaServed`) in `_includes/head/custom.html` as per the Search persona guidelines. Also updated the Coverage Tracker.

---
*PR created automatically by Jules for task [18236950348344277075](https://jules.google.com/task/18236950348344277075) started by @ryanofarrell*