### PR TITLE
Fix front matter schema and structure for basics-motor-planning.md

### DIFF
--- a/.Jules/ink.md
+++ b/.Jules/ink.md
@@ -170,7 +170,7 @@ done
 ## Coverage Tracker
 
 ### Posts (populate by running `ls _posts/`)
-- [ ] `2025-05-30-basics-motor-planning.md`
+- [x] `2025-05-30-basics-motor-planning.md` - 2026-06-03
 - [ ] *(run `ls _posts/` to discover remaining posts and add them here)*
 
 ### Taxonomy
@@ -181,4 +181,8 @@ done
 
 ## Execution Log
 
-*No entries yet. First audit pending.*
+## 2026-06-03 — Fix front matter schema and structure for basics-motor-planning.md
+- **Target:** `_posts/2025-05-30-basics-motor-planning.md`
+- **Finding:** The post was missing a `description`, used non-canonical `concepts` slugs, had `tag` instead of `tags`, its title was too long (> 60 chars), and lacked an `H2` within the first 200 words.
+- **Action:** Shortened `title`, added `description` (148 chars), updated `tags` to `["Posts", "Motor Planning"]`, updated `concepts` to canonical terms (`[motor-planning, body-awareness, sensory-processing, executive-function]`), and added `## What is Motor Planning?` as the first heading. Updated `_data/tags.yml` to include the new `Motor Planning` tag.
+- **Verification:** `bundle exec jekyll build` → ✅ Success

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -4,3 +4,5 @@ tag_colors:
     color: $secondary # Using $info as an example, choose a Bootstrap color variable or hex code
   "Posts":
     color: $secondary
+  "Motor Planning":
+    color: $primary

--- a/_posts/2025-05-30-basics-motor-planning.md
+++ b/_posts/2025-05-30-basics-motor-planning.md
@@ -1,16 +1,23 @@
 ---
 layout: post
-title: "Basics of Motor Planning: Helping Children Navigate Their World"
+title: "Motor Planning Basics: Helping Kids Navigate the World"
 date: 2025-05-30 09:00:00 -0400 # Replace with your desired publication date
-categories: posts
-tag: Posts
-concepts: ["motor planning", "praxis", "body awareness", "tactile processing", "ideation", "executive function"]
+categories: [posts]
+tags: ["Posts", "Motor Planning"]
+description: "Learn about motor planning (praxis), its essential components like body awareness, tactile processing, and ideation, and how to support your child."
+concepts:
+  - motor-planning
+  - body-awareness
+  - sensory-processing
+  - executive-function
 excerpt: "An exploration of motor planning (praxis), its essential components like body awareness, tactile processing, and ideation, and practical ways to support children's development in these areas."
 classes: wide
 header:
   teaser: "/assets/images/processed/blog/motor-planning.jpeg" 
 image: "/assets/images/processed/blog/motor-planning.jpeg" 
 ---
+
+## What is Motor Planning?
 
 Have you ever tried to bring in all of your groceries at once, just to save another trip to the car? This requires significant motor planning. Motor planning, also known as praxis, is the ability to perform a new or skilled motor task, and is dependent upon adequate body awareness, tactile processing, ideation, initiation, timing, sequencing, feedback and feedforward. It is how quickly we learn a motor skill and the ability to generalize it to other situations. A weakness with motor planning impacts the ability to think of what to do. For example, a child who has difficulty with motor planning may have difficulty carrying out multi step tasks such as getting themselves ready for school.
 


### PR DESCRIPTION
1. Shortened `title` to 54 characters.
2. Added `description` (148 characters) to front matter.
3. Updated `tag: Posts` to `tags: ["Posts", "Motor Planning"]`.
4. Updated `concepts` to only include exact canonical taxonomy slugs.
5. Added an `H2` heading `## What is Motor Planning?` within the first 200 words.
6. Updated `_data/tags.yml` to include color for `Motor Planning` tag.
7. Documented the fixes in `.Jules/ink.md` coverage tracker and execution log.

---
*PR created automatically by Jules for task [653767778536261531](https://jules.google.com/task/653767778536261531) started by @ryanofarrell*