### PR TITLE
docs: escalate hardcoded soft hooks in services.html

### DIFF
--- a/.Jules/convert.md
+++ b/.Jules/convert.md
@@ -153,7 +153,7 @@ done
 ## Coverage Tracker
 
 ### Static Pages — Hook Audit
-- [ ] `services.html` — Has hook? Contextually relevant?
+- [✅] `services.html` — Has hook? Contextually relevant? (2026-06-03)
 - [ ] `contact.html` — Has hook? Next step clear?
 - [ ] `faq.html` — Has hook? Guides to services or blog?
 - [ ] `meet-maria.html` — Has hook? Guides to services or contact?
@@ -170,4 +170,13 @@ done
 
 ## Execution Log
 
-*No entries yet. First audit pending.*
+## 2026-06-03 — Escalate multiple hardcoded soft hooks on services page
+- **Target:** `services.html`
+- **Finding:** Page contains multiple hardcoded `soft-hook-card` elements instead of using the `_includes/soft_hook.html` component, violating the max 1 frequency rule and component usage constraint.
+- **Action:** Since Palette owns `services.html` structure, logging an escalation.
+- **Verification:** `bundle exec jekyll build` → ✅ Success
+
+### ⚠️ ESCALATION → Palette 🎨
+- **File:** `services.html`
+- **Issue:** Page has multiple hardcoded `soft-hook-card` elements at the bottom instead of using the `_includes/soft_hook.html` component.
+- **Suggested Fix:** Remove the two hardcoded cards and replace them with a single `{% include soft_hook.html title="Looking for free resources?" text="Check out our blog for expert articles on child development." btn_text="Read the Blog" btn_link="/blog/" %}`.


### PR DESCRIPTION
Escalates an issue found during the `Convert` persona's audit of `services.html`. The page contained multiple hardcoded `.soft-hook-card` components instead of utilizing the `_includes/soft_hook.html` reusable component. Since structure is owned by `Palette`, the finding is logged as an escalation in `.Jules/convert.md`, and the coverage tracker is updated to mark the file as audited.

---
*PR created automatically by Jules for task [8921491063112251656](https://jules.google.com/task/8921491063112251656) started by @ryanofarrell*