### PR TITLE
chore(a11y): Complete accessibility audit for default.html

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -96,7 +96,7 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 **Instructions:** After auditing a file, mark it ✅ with the date. Pick the first unmarked file on each run.
 
 ### Layouts (`_layouts/`)
-- [ ] `default.html`
+- [x] `default.html` ✅ 2026-06-03
 - [ ] `home.html`
 - [ ] `post.html`
 - [ ] `page.html`
@@ -142,6 +142,12 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 ## Execution Log
 
 <!-- Palette's cumulative journal. New entries go at the top. -->
+
+### 2026-06-03 — No accessibility issues found
+- **Target:** `_layouts/default.html`
+- **Finding:** No new accessibility issues found. Previous skip-link fixes have resolved outstanding issues.
+- **Action:** None.
+- **Verification:** `bundle exec jekyll build` → ✅ Success
 
 ### 2026-02-14 — Focus states on custom icons
 - **Target:** `_sass/components/`, `_includes/navigation.html`


### PR DESCRIPTION
Completed accessibility audit for `_layouts/default.html` under the 'Palette' persona. As previous runs successfully implemented the `skip-link` and `<main>` wrapper, no new accessibility issues were found. The coverage tracker in `.Jules/palette.md` was updated accordingly and a journal entry added. The build succeeds.

---
*PR created automatically by Jules for task [10758762815655540296](https://jules.google.com/task/10758762815655540296) started by @ryanofarrell*