### PR TITLE
fix(a11y): correct heading hierarchy in post layout

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -98,7 +98,7 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 ### Layouts (`_layouts/`)
 - [x] `default.html` ✅ 2026-06-03
 - [x] `home.html` ✅ 2026-06-10
-- [ ] `post.html`
+- [x] `post.html` ✅ 2026-06-17
 - [ ] `page.html`
 - [ ] `single.html`
 - [ ] `minimal.html`
@@ -142,6 +142,12 @@ grep -rn '#[0-9a-fA-F]\{3,6\}' _sass/ --include='*.scss' | grep -v '_bootstrap\|
 ## Execution Log
 
 <!-- Palette's cumulative journal. New entries go at the top. -->
+
+### 2026-06-17 — Fix semantic HTML heading hierarchy in post layout
+- **Target:** `_layouts/post.html`
+- **Finding:** The "About the Author" section heading was improperly nested as an `<h3>`, making it a subsection of the preceding "Ready to connect?" CTA section, breaking the logical heading hierarchy.
+- **Action:** Upgraded the `<h3>` to an `<h2>` while applying the `.h3` utility class to maintain visual styling consistent with the rest of the site layout.
+- **Verification:** `bundle exec jekyll build` → ✅ Success
 
 ### 2026-06-10 — No accessibility issues found
 - **Target:** `_layouts/home.html`

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -70,7 +70,7 @@ layout: default
         {% assign maria = site.data.sitetext.team.people | where: "name", "Maria O'Farrell" | first %}
         {% if maria and site.data.sitetext.team.short_bio %}
           <div class="about-author-section p-4 mt-5 border-0 rounded bg-light" style="border-radius: 12px 28px 12px 24px !important;">
-            <h3 class="section-subheading text-center mb-4 text-primary font-weight-bold" style="font-size: 0.85rem; letter-spacing: 2px; text-transform: uppercase;">About the Author</h3>
+            <h2 class="h3 section-subheading text-center mb-4 text-primary font-weight-bold" style="font-size: 0.85rem; letter-spacing: 2px; text-transform: uppercase;">About the Author</h2>
             <div class="row align-items-center">
               <div class="col-auto">
                 {% assign img_src = maria.image %}


### PR DESCRIPTION
This PR addresses an accessibility issue in the post layout (`_layouts/post.html`) identified by the Palette persona during a routine audit. 

**Finding:** The "About the Author" section heading was improperly nested as an `<h3>`, making it a logical subsection of the preceding "Ready to connect?" CTA section, breaking the logical heading hierarchy for screen reader users.

**Action:** Upgraded the `<h3>` to an `<h2>` while applying the `.h3` utility class to maintain visual styling consistent with the rest of the site layout. Also updated the Palette coverage tracker.

---
*PR created automatically by Jules for task [17348249361489192730](https://jules.google.com/task/17348249361489192730) started by @ryanofarrell*